### PR TITLE
Refactor UI to Tailwind and fix ToC focus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,7 +123,7 @@ function App() {
                       content={document.content}
                       currentRelativePath={selectedFile}
                       knownDocuments={files}
-                      onNavigate={(file) => void openDocument(file)}
+                      onNavigate={openDocument}
                     />
                   ) : (
                     <EmptyReader />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,20 +38,17 @@ function App() {
   const selectedLabel = selectedSegments[selectedSegments.length - 1] ?? "문서를 선택하세요";
 
   return (
-    <div className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
-      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_top_left,rgba(165,180,252,0.18),transparent_32%),radial-gradient(circle_at_bottom_right,rgba(244,114,182,0.14),transparent_28%)]" />
-      <div className="pointer-events-none fixed inset-x-0 top-0 h-48 bg-[linear-gradient(180deg,rgba(15,23,42,0.06),transparent)]" />
-
+    <div className="min-h-screen bg-background text-foreground">
       <main className="relative mx-auto flex min-h-screen max-w-[1600px] flex-col px-4 py-4 sm:px-6">
-        <header className="mb-4 rounded-[28px] border border-white/60 bg-white/75 px-4 py-3 shadow-[0_24px_80px_rgba(15,23,42,0.08)] backdrop-blur-xl">
+        <header className="mb-4 rounded-lg border border-border bg-card px-4 py-3 text-card-foreground shadow-sm">
           <div className="flex items-center justify-between gap-3">
             <div className="flex min-w-0 items-center gap-3">
-              <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[var(--panel-strong)] text-white shadow-lg">
+              <div className="flex h-11 w-11 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-sm">
                 <FileText className="h-5 w-5" />
               </div>
               <div className="min-w-0">
-                <p className="font-display text-xl tracking-[0.18em] text-[var(--panel-strong)]">MARKMINI</p>
-                <div className="flex min-w-0 items-center gap-2 text-sm text-[var(--muted-foreground)]">
+                <p className="font-display text-xl font-semibold text-primary">MARKMINI</p>
+                <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
                   <span className="truncate">{rootDir ?? "루트 경로를 불러오는 중"}</span>
                 </div>
               </div>
@@ -106,19 +103,19 @@ function App() {
               <Card className="min-h-[70vh] overflow-hidden">
                 <CardContent className="flex h-full flex-col p-0">
                   <div className="border-b border-border/60 px-5 py-4">
-                    <div className="flex items-center gap-2 text-sm uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+                    <div className="flex items-center gap-2 text-sm font-medium uppercase tracking-widest text-muted-foreground">
                       <TextSearch className="h-4 w-4" />
                       Reader
                     </div>
-                    <h1 className="mt-2 truncate font-display text-2xl text-[var(--foreground)]">{selectedLabel}</h1>
+                    <h1 className="mt-2 truncate font-display text-2xl font-semibold text-foreground">{selectedLabel}</h1>
                   </div>
 
                   {document.state === "loading" ? (
-                    <div className="flex flex-1 items-center justify-center text-sm text-[var(--muted-foreground)]">
+                    <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
                       문서를 불러오는 중입니다.
                     </div>
                   ) : document.state === "error" ? (
-                    <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-[var(--destructive)]">
+                    <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-destructive">
                       {document.error}
                     </div>
                   ) : document.content ? (
@@ -151,8 +148,8 @@ function LoadingState() {
   return (
     <Card className="flex min-h-[70vh] items-center justify-center">
       <CardContent className="py-16 text-center">
-        <p className="font-display text-2xl tracking-[0.18em] text-[var(--panel-strong)]">MARKMINI</p>
-        <p className="mt-3 text-sm text-[var(--muted-foreground)]">로컬 markdown 세션을 준비하고 있습니다.</p>
+        <p className="font-display text-2xl font-semibold text-primary">MARKMINI</p>
+        <p className="mt-3 text-sm text-muted-foreground">로컬 markdown 세션을 준비하고 있습니다.</p>
       </CardContent>
     </Card>
   );
@@ -162,8 +159,8 @@ function ErrorState({ message, onRetry }: { message: string; onRetry: () => void
   return (
     <Card className="flex min-h-[70vh] items-center justify-center">
       <CardContent className="max-w-md py-16 text-center">
-        <p className="font-display text-2xl tracking-[0.16em] text-[var(--destructive)]">FAILED TO OPEN</p>
-        <p className="mt-4 text-sm leading-6 text-[var(--muted-foreground)]">{message}</p>
+        <p className="font-display text-2xl font-semibold text-destructive">FAILED TO OPEN</p>
+        <p className="mt-4 text-sm leading-6 text-muted-foreground">{message}</p>
         <Button className="mt-6" onClick={onRetry}>
           다시 시도
         </Button>
@@ -176,11 +173,11 @@ function EmptyReader() {
   return (
     <div className="flex flex-1 items-center justify-center px-6 py-12">
       <div className="max-w-sm text-center">
-        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-[var(--panel)] text-[var(--panel-strong)]">
+        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-md bg-secondary text-secondary-foreground">
           <FolderTree className="h-6 w-6" />
         </div>
-        <p className="mt-5 font-display text-xl tracking-[0.14em] text-[var(--panel-strong)]">NO DOCUMENT</p>
-        <p className="mt-3 text-sm leading-6 text-[var(--muted-foreground)]">
+        <p className="mt-5 font-display text-xl font-semibold text-primary">NO DOCUMENT</p>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
           현재 경로에서 markdown 파일을 찾지 못했거나 아직 선택된 문서가 없습니다.
         </p>
       </div>

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -23,7 +23,7 @@ export function FileTree({ files, selectedFile, onSelect }: FileTreeProps) {
         <ScrollArea className="h-full">
           <div className="px-3 py-4">
             {tree.length === 0 ? (
-              <p className="px-3 text-sm leading-6 text-[var(--muted-foreground)]">표시할 markdown 파일이 없습니다.</p>
+              <p className="px-3 text-sm leading-6 text-muted-foreground">표시할 markdown 파일이 없습니다.</p>
             ) : (
               <ul className="space-y-1">
                 {tree.map((node) => (
@@ -59,7 +59,7 @@ function TreeNode({
   if (node.kind === "directory") {
     return (
       <li>
-        <div className="mb-1 flex items-center gap-2 px-3 py-2 text-xs font-medium uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+        <div className="mb-1 flex items-center gap-2 px-3 py-2 text-xs font-medium uppercase tracking-widest text-muted-foreground">
           <FolderOpen className="h-4 w-4" />
           <span className="truncate">{node.name}</span>
         </div>
@@ -79,17 +79,22 @@ function TreeNode({
         type="button"
         onClick={() => onSelect(node.path)}
         className={cn(
-          "flex w-full items-center gap-2 rounded-2xl px-3 py-2.5 text-left transition-colors",
-          isSelected ? "bg-[var(--panel-strong)] text-white shadow-md" : "text-[var(--foreground)] hover:bg-white/70",
+          "flex w-full items-center gap-2 rounded-md py-2.5 pr-3 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+          treeNodeIndentClass(depth),
+          isSelected ? "bg-primary text-primary-foreground shadow-sm" : "text-foreground hover:bg-accent hover:text-accent-foreground",
         )}
-        style={{ paddingLeft: `${0.75 + depth * 0.75}rem` }}
       >
-        <ChevronRight className={cn("h-4 w-4 shrink-0", isSelected ? "opacity-80" : "text-[var(--muted-foreground)]")} />
+        <ChevronRight className={cn("h-4 w-4 shrink-0", isSelected ? "opacity-80" : "text-muted-foreground")} />
         <FileText className="h-4 w-4 shrink-0" />
         <span className="truncate text-sm">{fileLabel(node.path)}</span>
       </button>
     </li>
   );
+}
+
+function treeNodeIndentClass(depth: number) {
+  const classes = ["pl-3", "pl-6", "pl-9", "pl-12", "pl-14"];
+  return classes[Math.min(depth, classes.length - 1)];
 }
 
 function buildTree(files: string[]) {

--- a/src/components/markdown-view.tsx
+++ b/src/components/markdown-view.tsx
@@ -5,7 +5,7 @@ import remarkGfm from "remark-gfm";
 
 import { MermaidBlock } from "@/components/mermaid-block";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { focusHeadingById } from "@/lib/heading-navigation";
+import { focusHeadingById, focusHeadingByIdWhenReady } from "@/lib/heading-navigation";
 import { createSlugger, extractCodeText } from "@/lib/markdown";
 import { resolveMarkdownHref } from "@/lib/path";
 
@@ -13,7 +13,7 @@ interface MarkdownViewProps {
   content: string;
   currentRelativePath: string | null;
   knownDocuments: string[];
-  onNavigate: (relativePath: string) => void;
+  onNavigate: (relativePath: string) => Promise<void> | void;
 }
 
 const MERMAID_START_KEYWORDS = new Set([
@@ -96,12 +96,10 @@ export function MarkdownView({ content, currentRelativePath, knownDocuments, onN
                 <button
                   type="button"
                   className="cursor-pointer bg-transparent p-0 text-left text-inherit"
-                  onClick={() => {
-                    onNavigate(resolved.path);
+                  onClick={async () => {
+                    await onNavigate(resolved.path);
                     if (resolved.hash) {
-                      setTimeout(() => {
-                        focusHeadingById(resolved.hash!);
-                      }, 50);
+                      await focusHeadingByIdWhenReady(resolved.hash);
                     }
                   }}
                 >

--- a/src/components/markdown-view.tsx
+++ b/src/components/markdown-view.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 
 import { MermaidBlock } from "@/components/mermaid-block";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { focusHeadingById } from "@/lib/heading-navigation";
 import { createSlugger, extractCodeText } from "@/lib/markdown";
 import { resolveMarkdownHref } from "@/lib/path";
 
@@ -44,6 +45,23 @@ const MERMAID_START_KEYWORDS = new Set([
   "C4Deployment",
 ]);
 
+const markdownClassName = [
+  "prose prose-slate mx-auto w-full max-w-none px-5 py-8 text-foreground sm:px-8 sm:py-10",
+  "prose-headings:scroll-mt-24 prose-headings:font-display prose-headings:text-primary prose-headings:focus:outline-none prose-headings:focus-visible:ring-2 prose-headings:focus-visible:ring-ring",
+  "prose-h1:mt-0 prose-h1:text-4xl prose-h1:leading-tight",
+  "prose-h2:mt-12 prose-h2:text-2xl prose-h2:leading-tight",
+  "prose-h3:mt-8 prose-h3:text-xl prose-h3:leading-tight",
+  "prose-p:text-[15px] prose-p:leading-8 prose-li:text-[15px] prose-li:leading-8",
+  "prose-a:text-primary prose-a:decoration-accent-foreground/30 prose-a:underline-offset-4",
+  "prose-strong:text-primary prose-code:rounded-md prose-code:bg-secondary prose-code:px-1.5 prose-code:py-0.5 prose-code:text-primary",
+  "prose-pre:overflow-x-auto prose-pre:rounded-lg prose-pre:border prose-pre:border-border prose-pre:bg-primary prose-pre:text-sm prose-pre:text-primary-foreground prose-pre:shadow-inner",
+  "prose-blockquote:border-accent prose-blockquote:bg-background prose-blockquote:px-4 prose-blockquote:py-1 prose-blockquote:font-normal prose-blockquote:italic",
+  "prose-table:my-6 prose-table:w-full prose-table:overflow-hidden prose-table:rounded-lg prose-table:border prose-table:border-border prose-table:bg-background",
+  "prose-thead:bg-secondary prose-th:border-b prose-th:border-border prose-th:px-4 prose-th:py-3 prose-td:border-b prose-td:border-border prose-td:px-4 prose-td:py-3",
+  "prose-hr:border-border",
+  "[&_code::after]:content-none [&_code::before]:content-none [&_pre_code]:rounded-none [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:font-normal [&_pre_code]:text-inherit",
+].join(" ");
+
 function looksLikeMermaid(codeText: string): boolean {
   const firstLine = codeText.split(/\r?\n/).find((line) => line.trim().length > 0);
   if (!firstLine) {
@@ -58,7 +76,7 @@ export function MarkdownView({ content, currentRelativePath, knownDocuments, onN
 
   return (
     <ScrollArea className="h-[calc(100vh-13rem)]">
-      <div className="markdown-body">
+      <div className={markdownClassName}>
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[[rehypeHighlight, { ignoreMissing: true }]]}
@@ -82,8 +100,7 @@ export function MarkdownView({ content, currentRelativePath, knownDocuments, onN
                     onNavigate(resolved.path);
                     if (resolved.hash) {
                       setTimeout(() => {
-                        const target = document.getElementById(resolved.hash!);
-                        target?.scrollIntoView({ behavior: "smooth", block: "start" });
+                        focusHeadingById(resolved.hash!);
                       }, 50);
                     }
                   }}
@@ -99,11 +116,7 @@ export function MarkdownView({ content, currentRelativePath, knownDocuments, onN
                   href={`#${resolved.hash}`}
                   onClick={(event) => {
                     event.preventDefault();
-                    const target = document.getElementById(resolved.hash);
-                    if (target) {
-                      history.replaceState(null, "", `#${resolved.hash}`);
-                      target.scrollIntoView({ behavior: "smooth", block: "start" });
-                    }
+                    focusHeadingById(resolved.hash);
                   }}
                 >
                   {children}
@@ -136,15 +149,27 @@ export function MarkdownView({ content, currentRelativePath, knownDocuments, onN
           code: ({ className, children }) => <code className={className}>{children}</code>,
           h1: ({ children }) => {
             const id = createHeadingId(extractCodeText(children));
-            return <h1 id={id}>{children}</h1>;
+            return (
+              <h1 id={id} tabIndex={-1}>
+                {children}
+              </h1>
+            );
           },
           h2: ({ children }) => {
             const id = createHeadingId(extractCodeText(children));
-            return <h2 id={id}>{children}</h2>;
+            return (
+              <h2 id={id} tabIndex={-1}>
+                {children}
+              </h2>
+            );
           },
           h3: ({ children }) => {
             const id = createHeadingId(extractCodeText(children));
-            return <h3 id={id}>{children}</h3>;
+            return (
+              <h3 id={id} tabIndex={-1}>
+                {children}
+              </h3>
+            );
           },
         }}
         >

--- a/src/components/mermaid-block.tsx
+++ b/src/components/mermaid-block.tsx
@@ -4,6 +4,8 @@ interface MermaidBlockProps {
   chart: string;
 }
 
+const shellClassName = "not-prose my-6 overflow-hidden rounded-lg border border-border bg-background p-4 shadow-sm";
+
 export function MermaidBlock({ chart }: MermaidBlockProps) {
   const reactId = useId();
   const elementId = `mermaid-${reactId.replace(/:/g, "-")}`;
@@ -45,9 +47,9 @@ export function MermaidBlock({ chart }: MermaidBlockProps) {
 
   if (error) {
     return (
-      <div className="not-prose mermaid-shell">
-        <p className="font-medium text-[var(--destructive)]">Mermaid 렌더링에 실패했습니다.</p>
-        <pre className="mt-3 whitespace-pre-wrap break-words rounded-2xl border border-border/70 bg-[var(--secondary)] p-4 text-xs text-[var(--foreground)]">
+      <div className={shellClassName}>
+        <p className="font-medium text-destructive">Mermaid 렌더링에 실패했습니다.</p>
+        <pre className="mt-3 whitespace-pre-wrap break-words rounded-lg border border-border bg-secondary p-4 text-xs text-foreground">
           {error}
           {"\n\n"}
           {chart}
@@ -57,8 +59,8 @@ export function MermaidBlock({ chart }: MermaidBlockProps) {
   }
 
   if (!svg) {
-    return <div className="not-prose mermaid-shell text-sm text-[var(--muted-foreground)]">Mermaid chart 렌더링 중...</div>;
+    return <div className={`${shellClassName} text-sm text-muted-foreground`}>Mermaid chart 렌더링 중...</div>;
   }
 
-  return <div className="not-prose mermaid-shell mermaid-block" dangerouslySetInnerHTML={{ __html: svg }} />;
+  return <div className={`${shellClassName} [&_svg]:h-auto [&_svg]:max-w-full`} dangerouslySetInnerHTML={{ __html: svg }} />;
 }

--- a/src/components/table-of-contents.tsx
+++ b/src/components/table-of-contents.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { HeadingItem } from "@/types/content";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { focusHeadingById } from "@/lib/heading-navigation";
+import { cn } from "@/lib/utils";
 
 interface TableOfContentsProps {
   headings: HeadingItem[];
@@ -41,14 +43,14 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
     };
 
     updateActiveHeading();
-    window.addEventListener("scroll", scheduleUpdate, { passive: true });
+    window.addEventListener("scroll", scheduleUpdate, { capture: true, passive: true });
     window.addEventListener("hashchange", scheduleUpdate);
 
     return () => {
       if (frameId) {
         window.cancelAnimationFrame(frameId);
       }
-      window.removeEventListener("scroll", scheduleUpdate);
+      window.removeEventListener("scroll", scheduleUpdate, { capture: true });
       window.removeEventListener("hashchange", scheduleUpdate);
     };
   }, [headingIds, headings.length]);
@@ -80,7 +82,7 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
             TOC
           </CardTitle>
         </CardHeader>
-        <CardContent className="pt-0 text-sm text-[var(--muted-foreground)]">이 문서에는 표시할 제목이 없습니다.</CardContent>
+        <CardContent className="pt-0 text-sm text-muted-foreground">이 문서에는 표시할 제목이 없습니다.</CardContent>
       </Card>
     );
   }
@@ -94,8 +96,8 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
         </CardTitle>
       </CardHeader>
       <CardContent className="pt-0">
-        <ScrollArea className="toc-scroll pr-3">
-          <div ref={scrollViewportRef}>
+        <ScrollArea className="h-[min(60vh,calc(100vh-14rem))] pr-3" viewportRef={scrollViewportRef}>
+          <div>
             <nav aria-label="Table of contents">
               <ol className="space-y-1">
                 {headings.map((heading) => {
@@ -104,19 +106,19 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
                     <li key={heading.id}>
                       <a
                         href={`#${heading.id}`}
-                        className={`
-                          block rounded-2xl px-3 py-2 text-sm transition-colors
-                          ${isActive ? "bg-[var(--panel-strong)] text-white" : "text-[var(--muted-foreground)] hover:bg-white/70 hover:text-[var(--foreground)]"}
-                        `}
+                        className={cn(
+                          "block rounded-md py-2 pr-3 text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+                          tocIndentClass(heading.depth),
+                          isActive
+                            ? "bg-primary text-primary-foreground"
+                            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                        )}
                         aria-current={isActive ? "location" : undefined}
                         ref={isActive ? activeLinkRef : undefined}
-                        style={{ paddingLeft: `${0.75 + (heading.depth - 1) * 0.9}rem` }}
                         onClick={(event) => {
                           event.preventDefault();
-                          const target = document.getElementById(heading.id);
-                          if (target) {
-                            history.replaceState(null, "", `#${heading.id}`);
-                            target.scrollIntoView({ behavior: "smooth", block: "start" });
+                          if (focusHeadingById(heading.id)) {
+                            setActiveId(heading.id);
                           }
                         }}
                       >
@@ -132,6 +134,15 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
       </CardContent>
     </Card>
   );
+}
+
+function tocIndentClass(depth: HeadingItem["depth"]) {
+  const classes = {
+    1: "pl-3",
+    2: "pl-6",
+    3: "pl-9",
+  };
+  return classes[depth];
 }
 
 function resolveActiveHeadingId(headingIds: string[]) {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,13 +4,13 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium transition-all outline-none ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-[var(--panel-strong)] px-4 py-2.5 text-[var(--primary-foreground)] shadow-md hover:-translate-y-0.5 hover:shadow-lg",
-        outline: "border border-border/80 bg-white/70 px-4 py-2.5 text-[var(--foreground)] hover:bg-white",
-        ghost: "px-3 py-2 text-[var(--muted-foreground)] hover:bg-white/70 hover:text-[var(--foreground)]",
+        default: "bg-primary px-4 py-2.5 text-primary-foreground shadow-sm hover:bg-primary/90",
+        outline: "border border-border bg-background px-4 py-2.5 text-foreground hover:bg-accent hover:text-accent-foreground",
+        ghost: "px-3 py-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground",
       },
       size: {
         default: "h-10",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -5,10 +5,7 @@ import { cn } from "@/lib/utils";
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn(
-      "rounded-[28px] border border-white/60 bg-[var(--card)] text-[var(--card-foreground)] shadow-[0_24px_80px_rgba(15,23,42,0.08)] backdrop-blur-xl",
-      className,
-    )}
+    className={cn("rounded-lg border border-border bg-card text-card-foreground shadow-sm", className)}
     {...props}
   />
 ));
@@ -20,7 +17,7 @@ const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(({ className, ...props }, ref) => (
-  <h3 ref={ref} className={cn("font-display text-xl tracking-[0.08em]", className)} {...props} />
+  <h3 ref={ref} className={cn("font-display text-xl", className)} {...props} />
 ));
 CardTitle.displayName = "CardTitle";
 

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -5,10 +5,14 @@ import { cn } from "@/lib/utils";
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
+    viewportRef?: React.Ref<HTMLDivElement>;
+  }
+>(({ className, children, viewportRef, ...props }, ref) => (
   <ScrollAreaPrimitive.Root ref={ref} className={cn("relative overflow-hidden", className)} {...props}>
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">{children}</ScrollAreaPrimitive.Viewport>
+    <ScrollAreaPrimitive.Viewport ref={viewportRef} className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
     <ScrollBar />
     <ScrollAreaPrimitive.Corner />
   </ScrollAreaPrimitive.Root>
@@ -30,7 +34,7 @@ const ScrollBar = React.forwardRef<
     )}
     {...props}
   >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-[var(--border)]" />
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
 ));
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -30,7 +30,7 @@ const SheetContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed z-50 flex flex-col gap-4 border border-white/70 bg-[var(--popover)] p-6 shadow-2xl transition ease-out data-[state=closed]:animate-out data-[state=open]:animate-in",
+        "fixed z-50 flex flex-col gap-4 border bg-popover p-6 text-popover-foreground shadow-lg transition ease-out data-[state=closed]:animate-out data-[state=open]:animate-in",
         side === "left" && "inset-y-0 left-0 h-full border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
         side === "right" && "inset-y-0 right-0 h-full border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
         className,
@@ -38,7 +38,7 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <SheetClose className="absolute right-4 top-4 rounded-full p-1 text-[var(--muted-foreground)] hover:bg-[var(--secondary)]">
+      <SheetClose className="absolute right-4 top-4 rounded-md p-1 text-muted-foreground hover:bg-secondary">
         <X className="h-4 w-4" />
         <span className="sr-only">닫기</span>
       </SheetClose>
@@ -55,7 +55,7 @@ const SheetTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title ref={ref} className={cn("font-display text-xl tracking-[0.08em]", className)} {...props} />
+  <DialogPrimitive.Title ref={ref} className={cn("font-display text-xl", className)} {...props} />
 ));
 SheetTitle.displayName = DialogPrimitive.Title.displayName;
 

--- a/src/lib/heading-navigation.ts
+++ b/src/lib/heading-navigation.ts
@@ -1,0 +1,16 @@
+export function focusHeadingById(id: string) {
+  const target = document.getElementById(id);
+  if (!target) {
+    return false;
+  }
+
+  if (!target.hasAttribute("tabindex")) {
+    target.setAttribute("tabindex", "-1");
+  }
+
+  history.replaceState(null, "", `#${encodeURIComponent(id)}`);
+  target.scrollIntoView({ behavior: "smooth", block: "start" });
+  target.focus({ preventScroll: true });
+
+  return true;
+}

--- a/src/lib/heading-navigation.ts
+++ b/src/lib/heading-navigation.ts
@@ -14,3 +14,25 @@ export function focusHeadingById(id: string) {
 
   return true;
 }
+
+export function focusHeadingByIdWhenReady(id: string, timeoutMs = 1500) {
+  const startedAt = performance.now();
+
+  return new Promise<boolean>((resolve) => {
+    const tryFocus = () => {
+      if (focusHeadingById(id)) {
+        resolve(true);
+        return;
+      }
+
+      if (performance.now() - startedAt >= timeoutMs) {
+        resolve(false);
+        return;
+      }
+
+      window.requestAnimationFrame(tryFocus);
+    };
+
+    window.requestAnimationFrame(tryFocus);
+  });
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,66 +3,51 @@
 @plugin "@tailwindcss/typography";
 
 @theme {
-  --font-display: "Fraunces", "Iowan Old Style", "Palatino Linotype", serif;
-  --font-body: "IBM Plex Sans", "Segoe UI", sans-serif;
+  --font-display: Georgia, "Times New Roman", serif;
+  --font-sans: ui-sans-serif, system-ui, sans-serif;
 
-  --color-background: #f5f1e8;
-  --color-foreground: #18222f;
-  --color-card: rgba(255, 255, 255, 0.78);
-  --color-card-foreground: #18222f;
-  --color-popover: rgba(255, 255, 255, 0.96);
-  --color-popover-foreground: #18222f;
-  --color-primary: #18222f;
-  --color-primary-foreground: #f8f6f0;
-  --color-secondary: #efe3cf;
-  --color-secondary-foreground: #3b3128;
-  --color-muted: #eadfce;
-  --color-muted-foreground: #6b6a65;
-  --color-accent: #dcc4a3;
-  --color-accent-foreground: #2e241e;
-  --color-destructive: #b93834;
-  --color-border: rgba(24, 34, 47, 0.12);
-  --color-input: rgba(24, 34, 47, 0.14);
-  --color-ring: rgba(24, 34, 47, 0.24);
-  --color-panel: rgba(250, 245, 236, 0.88);
-  --color-panel-strong: #233347;
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
 }
 
 :root {
-  font-family: var(--font-body);
-  color: var(--color-foreground);
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.25), transparent 32%),
-    linear-gradient(135deg, #f8f4eb 0%, #f1ebdf 50%, #e9e0d1 100%);
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-
-  --background: var(--color-background);
-  --foreground: var(--color-foreground);
-  --card: var(--color-card);
-  --card-foreground: var(--color-card-foreground);
-  --popover: var(--color-popover);
-  --popover-foreground: var(--color-popover-foreground);
-  --primary: var(--color-primary);
-  --primary-foreground: var(--color-primary-foreground);
-  --secondary: var(--color-secondary);
-  --secondary-foreground: var(--color-secondary-foreground);
-  --muted: var(--color-muted);
-  --muted-foreground: var(--color-muted-foreground);
-  --accent: var(--color-accent);
-  --accent-foreground: var(--color-accent-foreground);
-  --destructive: var(--color-destructive);
-  --border: var(--color-border);
-  --input: var(--color-input);
-  --ring: var(--color-ring);
-  --panel: var(--color-panel);
-  --panel-strong: var(--color-panel-strong);
-  --radius: 1.25rem;
-}
-
-* {
-  border-color: var(--border);
+  --background: 48 30% 96%;
+  --foreground: 215 31% 15%;
+  --card: 0 0% 100%;
+  --card-foreground: 215 31% 15%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 215 31% 15%;
+  --primary: 215 38% 21%;
+  --primary-foreground: 48 45% 96%;
+  --secondary: 38 38% 88%;
+  --secondary-foreground: 26 28% 20%;
+  --muted: 39 33% 90%;
+  --muted-foreground: 45 4% 41%;
+  --accent: 34 42% 75%;
+  --accent-foreground: 24 30% 15%;
+  --destructive: 2 56% 46%;
+  --destructive-foreground: 48 45% 96%;
+  --border: 215 26% 18% / 0.12;
+  --input: 215 26% 18% / 0.14;
+  --ring: 215 26% 18% / 0.24;
+  --radius: 0.5rem;
 }
 
 html {
@@ -73,6 +58,12 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font-family: var(--font-sans);
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 #root {
@@ -83,51 +74,4 @@ button,
 input,
 textarea {
   font: inherit;
-}
-
-.font-display {
-  font-family: var(--font-display);
-}
-
-.markdown-body {
-  @apply prose prose-slate mx-auto w-full max-w-none px-5 py-8 text-[var(--foreground)] sm:px-8 sm:py-10;
-  @apply prose-headings:scroll-mt-24 prose-headings:font-display prose-headings:text-[var(--panel-strong)];
-  @apply prose-h1:mt-0 prose-h1:text-4xl prose-h1:leading-tight;
-  @apply prose-h2:mt-12 prose-h2:text-2xl prose-h2:leading-tight;
-  @apply prose-h3:mt-8 prose-h3:text-xl prose-h3:leading-tight;
-  @apply prose-p:text-[15px] prose-p:leading-8 prose-li:text-[15px] prose-li:leading-8;
-  @apply prose-a:text-[var(--panel-strong)] prose-a:decoration-[var(--accent-foreground)]/30 prose-a:underline-offset-4;
-  @apply prose-strong:text-[var(--panel-strong)] prose-code:rounded-md prose-code:bg-[var(--secondary)] prose-code:px-1.5 prose-code:py-0.5 prose-code:text-[var(--panel-strong)];
-  @apply prose-pre:overflow-x-auto prose-pre:rounded-[1.25rem] prose-pre:border prose-pre:border-border/70 prose-pre:bg-[var(--panel-strong)] prose-pre:text-sm prose-pre:text-white prose-pre:shadow-inner;
-  @apply prose-blockquote:border-[var(--accent)] prose-blockquote:bg-white/50 prose-blockquote:px-4 prose-blockquote:py-1 prose-blockquote:font-normal prose-blockquote:italic;
-  @apply prose-table:my-6 prose-table:w-full prose-table:overflow-hidden prose-table:rounded-2xl prose-table:border prose-table:border-border/70 prose-table:bg-white/70;
-  @apply prose-thead:bg-[var(--secondary)] prose-th:border-b prose-th:border-border/50 prose-th:px-4 prose-th:py-3 prose-td:border-b prose-td:border-border/50 prose-td:px-4 prose-td:py-3;
-  @apply prose-hr:border-border/80;
-}
-
-.markdown-body :where(pre code)::before,
-.markdown-body :where(pre code)::after,
-.markdown-body :where(code):not(:where(pre code))::before,
-.markdown-body :where(code):not(:where(pre code))::after {
-  content: none;
-}
-
-.markdown-body :where(pre code) {
-  background: transparent;
-  padding: 0;
-  border-radius: 0;
-  color: inherit;
-  font-weight: inherit;
-}
-
-.mermaid-block svg {
-  @apply h-auto max-w-full;
-}
-
-.mermaid-shell {
-  @apply my-6 overflow-hidden rounded-[1.4rem] border border-border/70 bg-white/75 p-4 shadow-sm;
-}
-
-.toc-scroll [data-radix-scroll-area-viewport] {
-  @apply max-h-[60vh];
 }


### PR DESCRIPTION
## Summary
- remove component-specific custom CSS classes and move Markdown/Mermaid/ToC styling into Tailwind class composition
- align local shadcn-style primitives with token-based Tailwind classes and smaller radius defaults
- focus Markdown headings when navigating from Table of Contents or hash links, including Radix ScrollArea scroll events

## Verification
- pnpm typecheck
- pnpm build

Closes #1
Closes #2