### PR TITLE
Stream markdown document tree discovery

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,10 +69,18 @@ struct FsChangePayload {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+enum ScanStatus {
+    Scanning,
+    Completed,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct ScanProgressPayload {
     files: Vec<String>,
     selected_file: Option<String>,
-    status: String,
+    status: ScanStatus,
     skipped_paths: Vec<String>,
     error: Option<String>,
 }
@@ -264,7 +272,7 @@ fn populate_session_async(
         ScanProgressPayload {
             files: Vec::new(),
             selected_file: None,
-            status: "scanning".to_string(),
+            status: ScanStatus::Scanning,
             skipped_paths: Vec::new(),
             error: None,
         },
@@ -318,7 +326,7 @@ fn populate_session_async(
             ScanProgressPayload {
                 files: emitted_files,
                 selected_file: selected_file.clone(),
-                status: "scanning".to_string(),
+                status: ScanStatus::Scanning,
                 skipped_paths: emitted_skipped_paths,
                 error: None,
             },
@@ -370,9 +378,9 @@ fn populate_session_async(
     }
 
     let final_status = if error.is_some() {
-        "error"
+        ScanStatus::Error
     } else {
-        "completed"
+        ScanStatus::Completed
     };
     {
         let state = app_handle.state::<AppState>();
@@ -389,7 +397,7 @@ fn populate_session_async(
         ScanProgressPayload {
             files,
             selected_file,
-            status: final_status.to_string(),
+            status: final_status,
             skipped_paths,
             error,
         },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,8 +4,7 @@ use notify::{
 use serde::Serialize;
 use std::{
     collections::HashMap,
-    env,
-    fs,
+    env, fs,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU32, Ordering},
@@ -56,6 +55,11 @@ struct AppState {
     window_counter: AtomicU32,
 }
 
+enum ScanEntry {
+    File(String),
+    Skipped(String),
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct FsChangePayload {
@@ -63,7 +67,19 @@ struct FsChangePayload {
     tree_changed: bool,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ScanProgressPayload {
+    files: Vec<String>,
+    selected_file: Option<String>,
+    status: String,
+    skipped_paths: Vec<String>,
+    error: Option<String>,
+}
+
 const FS_CHANGE_EVENT: &str = "markmini://fs-change";
+const SCAN_PROGRESS_EVENT: &str = "markmini://scan-progress";
+const SCAN_BATCH_SIZE: usize = 64;
 
 // ---------------------------------------------------------------------------
 // Tauri commands — all receive WebviewWindow to identify the calling window
@@ -145,8 +161,13 @@ fn read_markdown_file(
     }
 
     let file_path = session.root_dir.join(&relative_path);
-    let content = fs::read_to_string(&file_path)
-        .map_err(|error| format!("failed to read markdown file {}: {}", file_path.display(), error))?;
+    let content = fs::read_to_string(&file_path).map_err(|error| {
+        format!(
+            "failed to read markdown file {}: {}",
+            file_path.display(),
+            error
+        )
+    })?;
 
     Ok(MarkdownDocument {
         relative_path,
@@ -161,8 +182,7 @@ fn read_markdown_file(
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let current_dir =
-        env::current_dir().expect("failed to resolve current directory");
+    let current_dir = env::current_dir().expect("failed to resolve current directory");
     let raw_arg = env::args().nth(1);
     let target = resolve_target_from_args(raw_arg.as_deref(), &current_dir)
         .expect("failed to resolve launch target");
@@ -234,36 +254,144 @@ fn populate_session_async(
     root_dir: PathBuf,
     selected_hint: Option<PathBuf>,
 ) {
-    let mut files = match collect_markdown_files(&root_dir) {
-        Ok(files) => files,
-        Err(error) => {
-            eprintln!("failed to scan {}: {}", root_dir.display(), error);
-            Vec::new()
+    let selected_hint_relative = selected_hint
+        .as_ref()
+        .and_then(|hint| path_to_relative(&root_dir, hint));
+
+    let _ = app_handle.emit_to(
+        label,
+        SCAN_PROGRESS_EVENT,
+        ScanProgressPayload {
+            files: Vec::new(),
+            selected_file: None,
+            status: "scanning".to_string(),
+            skipped_paths: Vec::new(),
+            error: None,
+        },
+    );
+
+    let mut files = Vec::<String>::new();
+    let mut pending_files = Vec::<String>::new();
+    let mut skipped_paths = Vec::<String>::new();
+    let mut pending_skipped_paths = Vec::<String>::new();
+    let mut selected_file = None::<String>;
+
+    let flush_progress = |app_handle: &tauri::AppHandle,
+                          files: &mut Vec<String>,
+                          pending_files: &mut Vec<String>,
+                          pending_skipped_paths: &mut Vec<String>,
+                          selected_file: &mut Option<String>| {
+        if pending_files.is_empty() && pending_skipped_paths.is_empty() {
+            return;
         }
+
+        pending_files.sort();
+        pending_files.dedup();
+
+        if selected_file.is_none() {
+            if let Some(hint) = &selected_hint_relative {
+                if pending_files.iter().any(|entry| entry == hint) {
+                    *selected_file = Some(hint.clone());
+                }
+            }
+        }
+
+        {
+            let state = app_handle.state::<AppState>();
+            let mut sessions = state.sessions.lock().expect("sessions lock poisoned");
+            if let Some(session) = sessions.get_mut(label) {
+                merge_sorted_unique(&mut session.files, pending_files);
+                session.selected_file = selected_file.clone();
+            }
+        }
+
+        merge_sorted_unique(files, pending_files);
+
+        let emitted_files = pending_files.clone();
+        let emitted_skipped_paths = pending_skipped_paths.clone();
+        pending_files.clear();
+        pending_skipped_paths.clear();
+
+        let _ = app_handle.emit_to(
+            label,
+            SCAN_PROGRESS_EVENT,
+            ScanProgressPayload {
+                files: emitted_files,
+                selected_file: selected_file.clone(),
+                status: "scanning".to_string(),
+                skipped_paths: emitted_skipped_paths,
+                error: None,
+            },
+        );
     };
+
+    let scan_result = visit_dir_streaming(&root_dir, &root_dir, &mut |entry| {
+        match entry {
+            ScanEntry::File(relative) => pending_files.push(relative),
+            ScanEntry::Skipped(skipped) => {
+                skipped_paths.push(skipped.clone());
+                pending_skipped_paths.push(skipped);
+            }
+        }
+
+        if pending_files.len() >= SCAN_BATCH_SIZE || pending_skipped_paths.len() >= SCAN_BATCH_SIZE
+        {
+            flush_progress(
+                app_handle,
+                &mut files,
+                &mut pending_files,
+                &mut pending_skipped_paths,
+                &mut selected_file,
+            );
+        }
+    });
+
+    flush_progress(
+        app_handle,
+        &mut files,
+        &mut pending_files,
+        &mut pending_skipped_paths,
+        &mut selected_file,
+    );
+
+    let error = scan_result.err().map(|error| {
+        eprintln!("failed to scan {}: {}", root_dir.display(), error);
+        error
+    });
+
     files.sort();
+    files.dedup();
 
-    let selected_file = match &selected_hint {
-        Some(hint) => path_to_relative(&root_dir, hint),
-        None => pick_default_document(&files),
+    if selected_file.is_none() {
+        selected_file = match &selected_hint_relative {
+            Some(hint) if files.iter().any(|entry| entry == hint) => Some(hint.clone()),
+            _ => pick_default_document(&files),
+        };
+    }
+
+    let final_status = if error.is_some() {
+        "error"
+    } else {
+        "completed"
     };
-
     {
         let state = app_handle.state::<AppState>();
         let mut sessions = state.sessions.lock().expect("sessions lock poisoned");
         if let Some(session) = sessions.get_mut(label) {
-            session.files = files;
-            session.selected_file = selected_file;
+            session.files = files.clone();
+            session.selected_file = selected_file.clone();
         }
     }
 
-    // Notify the frontend via the existing fs-change channel.
     let _ = app_handle.emit_to(
         label,
-        FS_CHANGE_EVENT,
-        FsChangePayload {
-            changed_paths: Vec::new(),
-            tree_changed: true,
+        SCAN_PROGRESS_EVENT,
+        ScanProgressPayload {
+            files,
+            selected_file,
+            status: final_status.to_string(),
+            skipped_paths,
+            error,
         },
     );
 
@@ -321,14 +449,10 @@ fn handle_new_instance(app: &tauri::AppHandle, argv: Vec<String>, cwd: String) {
         );
     }
 
-    let builder = WebviewWindowBuilder::new(
-        app,
-        &label,
-        WebviewUrl::App("index.html".into()),
-    )
-    .title(&window_title)
-    .inner_size(1440.0, 920.0)
-    .min_inner_size(1080.0, 720.0);
+    let builder = WebviewWindowBuilder::new(app, &label, WebviewUrl::App("index.html".into()))
+        .title(&window_title)
+        .inner_size(1440.0, 920.0)
+        .min_inner_size(1080.0, 720.0);
 
     match builder.build() {
         Ok(_) => {
@@ -492,8 +616,9 @@ fn resolve_target_from_args(raw_arg: Option<&str>, cwd: &Path) -> Result<PathBuf
         Some(value) if !value.is_empty() => resolve_arg_path(value, cwd)?,
         _ => {
             let dir = sensible_default_dir(cwd);
-            dir.canonicalize()
-                .map_err(|error| format!("failed to resolve directory {}: {}", dir.display(), error))?
+            dir.canonicalize().map_err(|error| {
+                format!("failed to resolve directory {}: {}", dir.display(), error)
+            })?
         }
     };
 
@@ -526,9 +651,13 @@ fn sensible_default_dir(cwd: &Path) -> PathBuf {
 fn resolve_arg_path(raw_arg: &str, current_dir: &Path) -> Result<PathBuf, String> {
     let path = PathBuf::from(raw_arg);
     if path.is_absolute() {
-        return path
-            .canonicalize()
-            .map_err(|error| format!("failed to resolve launch target {}: {}", path.display(), error));
+        return path.canonicalize().map_err(|error| {
+            format!(
+                "failed to resolve launch target {}: {}",
+                path.display(),
+                error
+            )
+        });
     }
 
     let mut base_dirs: Vec<PathBuf> = Vec::new();
@@ -566,7 +695,10 @@ fn resolve_arg_path(raw_arg: &str, current_dir: &Path) -> Result<PathBuf, String
         dedupe_paths(vec![
             PathBuf::from(env::var("PWD").unwrap_or_default()),
             current_dir.to_path_buf(),
-            current_dir.parent().map(Path::to_path_buf).unwrap_or_default(),
+            current_dir
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_default(),
             manifest_parent.clone().unwrap_or_default(),
         ])
         .into_iter()
@@ -635,6 +767,60 @@ fn visit_dir(root_dir: &Path, directory: &Path, files: &mut Vec<String>) -> Resu
     }
 
     Ok(())
+}
+
+fn visit_dir_streaming(
+    root_dir: &Path,
+    directory: &Path,
+    on_entry: &mut impl FnMut(ScanEntry),
+) -> Result<(), String> {
+    let entries = match fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(_) => {
+            if let Some(relative) = path_to_relative(root_dir, directory) {
+                on_entry(ScanEntry::Skipped(relative));
+            }
+            return Ok(());
+        }
+    };
+
+    for entry_result in entries {
+        let entry = match entry_result {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+
+        if path.is_dir() {
+            if should_skip_dir(&path) {
+                if let Some(relative) = path_to_relative(root_dir, &path) {
+                    on_entry(ScanEntry::Skipped(relative));
+                }
+                continue;
+            }
+
+            visit_dir_streaming(root_dir, &path, on_entry)?;
+            continue;
+        }
+
+        if is_markdown_file(&path) {
+            if let Some(relative) = path_to_relative(root_dir, &path) {
+                on_entry(ScanEntry::File(relative));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn merge_sorted_unique(target: &mut Vec<String>, incoming: &[String]) {
+    for path in incoming {
+        if !target.iter().any(|existing| existing == path) {
+            target.push(path.clone());
+        }
+    }
+    target.sort();
+    target.dedup();
 }
 
 fn should_skip_dir(path: &Path) -> bool {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { useAppStore } from "@/store/app-store";
-import { subscribeToFsChanges } from "@/store/fs-watcher";
+import { subscribeToFsChanges, subscribeToScanProgress } from "@/store/fs-watcher";
 
 function App() {
   const bootstrap = useAppStore((state) => state.bootstrap);
@@ -18,6 +18,9 @@ function App() {
   const error = useAppStore((state) => state.error);
   const rootDir = useAppStore((state) => state.rootDir);
   const files = useAppStore((state) => state.files);
+  const scanState = useAppStore((state) => state.scanState);
+  const scanSkippedPaths = useAppStore((state) => state.scanSkippedPaths);
+  const scanError = useAppStore((state) => state.scanError);
   const selectedFile = useAppStore((state) => state.selectedFile);
   const document = useAppStore((state) => state.document);
   const isSidebarOpen = useAppStore((state) => state.isSidebarOpen);
@@ -29,6 +32,13 @@ function App() {
 
   useEffect(() => {
     const unlistenPromise = subscribeToFsChanges();
+    return () => {
+      void unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, []);
+
+  useEffect(() => {
+    const unlistenPromise = subscribeToScanProgress();
     return () => {
       void unlistenPromise.then((unlisten) => unlisten());
     };
@@ -69,6 +79,8 @@ function App() {
                   <div className="h-[calc(100vh-72px)] overflow-hidden">
                     <FileTree
                       files={files}
+                      scanState={scanState}
+                      skippedCount={scanSkippedPaths.length}
                       selectedFile={selectedFile}
                       onSelect={(file) => {
                         void openDocument(file);
@@ -95,7 +107,13 @@ function App() {
           <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[300px_minmax(0,1fr)]">
             <aside className="hidden min-h-0 lg:block">
               <div className="sticky top-4 h-[calc(100vh-8rem)]">
-                <FileTree files={files} selectedFile={selectedFile} onSelect={(file) => void openDocument(file)} />
+                <FileTree
+                  files={files}
+                  scanState={scanState}
+                  skippedCount={scanSkippedPaths.length}
+                  selectedFile={selectedFile}
+                  onSelect={(file) => void openDocument(file)}
+                />
               </div>
             </aside>
 
@@ -133,6 +151,11 @@ function App() {
 
               <aside className="min-h-0">
                 <div className="sticky top-4">
+                  {scanError ? (
+                    <div className="mb-4 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                      {scanError}
+                    </div>
+                  ) : null}
                   <TableOfContents headings={document.headings} />
                 </div>
               </aside>

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -5,14 +5,17 @@ import { fileLabel } from "@/lib/path";
 import { cn } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import type { ScanStatus } from "@/types/content";
 
 interface FileTreeProps {
   files: string[];
+  scanState: ScanStatus;
+  skippedCount: number;
   selectedFile: string | null;
   onSelect: (relativePath: string) => void;
 }
 
-export function FileTree({ files, selectedFile, onSelect }: FileTreeProps) {
+export function FileTree({ files, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
   const tree = useMemo(() => buildTree(files), [files]);
   const directoryPaths = useMemo(() => collectDirectoryPaths(tree), [tree]);
   const hasInitializedExpansionRef = useRef(false);
@@ -154,6 +157,12 @@ export function FileTree({ files, selectedFile, onSelect }: FileTreeProps) {
             {files.length}
           </span>
         </div>
+        {scanState === "scanning" || skippedCount > 0 ? (
+          <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+            <span>{scanState === "scanning" ? "문서를 찾는 중입니다." : "문서 탐색 완료"}</span>
+            {skippedCount > 0 ? <span>{skippedCount}개 경로 건너뜀</span> : null}
+          </div>
+        ) : null}
       </CardHeader>
       <CardContent className="h-[calc(100%-78px)] p-0">
         <ScrollArea className="h-full">

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,14 +1,23 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
-import type { InitialSession, MarkdownDocument } from "@/types/content";
+import type { InitialSession, MarkdownDocument, ScanStatus } from "@/types/content";
 
 export interface FsChangePayload {
   changedPaths: string[];
   treeChanged: boolean;
 }
 
+export interface ScanProgressPayload {
+  files: string[];
+  selectedFile: string | null;
+  status: ScanStatus;
+  skippedPaths: string[];
+  error: string | null;
+}
+
 const FS_CHANGE_EVENT = "markmini://fs-change";
+const SCAN_PROGRESS_EVENT = "markmini://scan-progress";
 
 export function getInitialSession() {
   return invoke<InitialSession>("get_initial_session");
@@ -24,4 +33,8 @@ export function readMarkdownFile(relativePath: string) {
 
 export function listenToFsChanges(handler: (payload: FsChangePayload) => void): Promise<UnlistenFn> {
   return listen<FsChangePayload>(FS_CHANGE_EVENT, (event) => handler(event.payload));
+}
+
+export function listenToScanProgress(handler: (payload: ScanProgressPayload) => void): Promise<UnlistenFn> {
+  return listen<ScanProgressPayload>(SCAN_PROGRESS_EVENT, (event) => handler(event.payload));
 }

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -12,8 +12,10 @@ interface AppStore {
   error: string | null;
   rootDir: string | null;
   files: string[];
+  fileSet: ReadonlySet<string>;
   scanState: ScanStatus;
   scanSkippedPaths: string[];
+  scanSkippedPathSet: ReadonlySet<string>;
   scanError: string | null;
   selectedFile: string | null;
   isSidebarOpen: boolean;
@@ -36,8 +38,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
   error: null,
   rootDir: null,
   files: [],
+  fileSet: new Set(),
   scanState: "idle",
   scanSkippedPaths: [],
+  scanSkippedPathSet: new Set(),
   scanError: null,
   selectedFile: null,
   isSidebarOpen: false,
@@ -50,8 +54,16 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setSidebarOpen: (open) => set({ isSidebarOpen: open }),
   applyScanProgress: async (payload) => {
     const state = get();
-    const files = mergeSortedUnique(state.files, payload.files);
-    const scanSkippedPaths = mergeSortedUnique(state.scanSkippedPaths, payload.skippedPaths);
+    const { values: files, valueSet: fileSet } = mergeSortedUnique(
+      state.files,
+      state.fileSet,
+      payload.files,
+    );
+    const { values: scanSkippedPaths, valueSet: scanSkippedPathSet } = mergeSortedUnique(
+      state.scanSkippedPaths,
+      state.scanSkippedPathSet,
+      payload.skippedPaths,
+    );
     const shouldOpenSelectedFile =
       payload.selectedFile &&
       payload.selectedFile !== state.selectedFile &&
@@ -60,8 +72,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
     set({
       bootstrapState: state.bootstrapState === "loading" ? "ready" : state.bootstrapState,
       files,
+      fileSet,
       scanState: payload.status,
       scanSkippedPaths,
+      scanSkippedPathSet,
       scanError: payload.error,
       selectedFile: shouldOpenSelectedFile ? payload.selectedFile : state.selectedFile,
     });
@@ -76,6 +90,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       error: null,
       scanState: "scanning",
       scanSkippedPaths: [],
+      scanSkippedPathSet: new Set(),
       scanError: null,
       document: {
         state: "idle",
@@ -87,10 +102,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     try {
       const session = await getInitialSession();
+      const { values: files, valueSet: fileSet } = mergeSortedUnique([], new Set(), session.files);
       set({
         bootstrapState: "ready",
         rootDir: session.rootDir,
-        files: mergeSortedUnique([], session.files),
+        files,
+        fileSet,
         selectedFile: session.selectedFile,
       });
 
@@ -171,13 +188,16 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     try {
       const session = await refreshSession();
+      const { values: files, valueSet: fileSet } = mergeSortedUnique([], new Set(), session.files);
       set({
         bootstrapState: "ready",
         error: null,
         rootDir: session.rootDir,
-        files: mergeSortedUnique([], session.files),
+        files,
+        fileSet,
         scanState: "completed",
         scanSkippedPaths: [],
+        scanSkippedPathSet: new Set(),
         scanError: null,
       });
 
@@ -207,10 +227,23 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 }));
 
-function mergeSortedUnique(current: string[], incoming: string[]) {
-  const next = new Set(current);
+function mergeSortedUnique(current: string[], currentSet: ReadonlySet<string>, incoming: string[]) {
+  let hasNewValue = false;
+  const next = new Set(currentSet);
+
   for (const value of incoming) {
+    if (!next.has(value)) {
+      hasNewValue = true;
+    }
     next.add(value);
   }
-  return [...next].sort((a, b) => a.localeCompare(b));
+
+  if (!hasNewValue && next.size === current.length) {
+    return { values: current, valueSet: currentSet };
+  }
+
+  return {
+    values: [...next].sort((a, b) => a.localeCompare(b)),
+    valueSet: next,
+  };
 }

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -1,8 +1,8 @@
 import { create } from "zustand";
 
 import { extractHeadings } from "@/lib/markdown";
-import { getInitialSession, readMarkdownFile, refreshSession } from "@/lib/tauri";
-import type { HeadingItem } from "@/types/content";
+import { getInitialSession, readMarkdownFile, refreshSession, type ScanProgressPayload } from "@/lib/tauri";
+import type { HeadingItem, ScanStatus } from "@/types/content";
 
 type BootstrapState = "idle" | "loading" | "ready" | "error";
 type DocumentState = "idle" | "loading" | "ready" | "error";
@@ -12,6 +12,9 @@ interface AppStore {
   error: string | null;
   rootDir: string | null;
   files: string[];
+  scanState: ScanStatus;
+  scanSkippedPaths: string[];
+  scanError: string | null;
   selectedFile: string | null;
   isSidebarOpen: boolean;
   document: {
@@ -21,6 +24,7 @@ interface AppStore {
     error: string | null;
   };
   setSidebarOpen: (open: boolean) => void;
+  applyScanProgress: (payload: ScanProgressPayload) => Promise<void>;
   bootstrap: () => Promise<void>;
   openDocument: (relativePath: string) => Promise<void>;
   reloadCurrentDocument: () => Promise<void>;
@@ -32,6 +36,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
   error: null,
   rootDir: null,
   files: [],
+  scanState: "idle",
+  scanSkippedPaths: [],
+  scanError: null,
   selectedFile: null,
   isSidebarOpen: false,
   document: {
@@ -41,10 +48,35 @@ export const useAppStore = create<AppStore>((set, get) => ({
     error: null,
   },
   setSidebarOpen: (open) => set({ isSidebarOpen: open }),
+  applyScanProgress: async (payload) => {
+    const state = get();
+    const files = mergeSortedUnique(state.files, payload.files);
+    const scanSkippedPaths = mergeSortedUnique(state.scanSkippedPaths, payload.skippedPaths);
+    const shouldOpenSelectedFile =
+      payload.selectedFile &&
+      payload.selectedFile !== state.selectedFile &&
+      (!state.selectedFile || state.document.state === "idle");
+
+    set({
+      bootstrapState: state.bootstrapState === "loading" ? "ready" : state.bootstrapState,
+      files,
+      scanState: payload.status,
+      scanSkippedPaths,
+      scanError: payload.error,
+      selectedFile: shouldOpenSelectedFile ? payload.selectedFile : state.selectedFile,
+    });
+
+    if (shouldOpenSelectedFile && payload.selectedFile) {
+      await get().openDocument(payload.selectedFile);
+    }
+  },
   bootstrap: async () => {
     set({
       bootstrapState: "loading",
       error: null,
+      scanState: "scanning",
+      scanSkippedPaths: [],
+      scanError: null,
       document: {
         state: "idle",
         content: "",
@@ -58,7 +90,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       set({
         bootstrapState: "ready",
         rootDir: session.rootDir,
-        files: session.files,
+        files: mergeSortedUnique([], session.files),
         selectedFile: session.selectedFile,
       });
 
@@ -143,7 +175,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
         bootstrapState: "ready",
         error: null,
         rootDir: session.rootDir,
-        files: session.files,
+        files: mergeSortedUnique([], session.files),
+        scanState: "completed",
+        scanSkippedPaths: [],
+        scanError: null,
       });
 
       const nextSelection =
@@ -171,3 +206,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }
   },
 }));
+
+function mergeSortedUnique(current: string[], incoming: string[]) {
+  const next = new Set(current);
+  for (const value of incoming) {
+    next.add(value);
+  }
+  return [...next].sort((a, b) => a.localeCompare(b));
+}

--- a/src/store/fs-watcher.ts
+++ b/src/store/fs-watcher.ts
@@ -1,6 +1,6 @@
 import type { UnlistenFn } from "@tauri-apps/api/event";
 
-import { listenToFsChanges } from "@/lib/tauri";
+import { listenToFsChanges, listenToScanProgress } from "@/lib/tauri";
 import { useAppStore } from "@/store/app-store";
 
 const DEBOUNCE_MS = 200;
@@ -41,5 +41,11 @@ export function subscribeToFsChanges(): Promise<UnlistenFn> {
       window.clearTimeout(timeoutId);
     }
     timeoutId = window.setTimeout(flush, DEBOUNCE_MS);
+  });
+}
+
+export function subscribeToScanProgress(): Promise<UnlistenFn> {
+  return listenToScanProgress((payload) => {
+    void useAppStore.getState().applyScanProgress(payload);
   });
 }

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -10,6 +10,8 @@ export interface InitialSession {
   selectedFile: string | null;
 }
 
+export type ScanStatus = "idle" | "scanning" | "completed" | "error";
+
 export interface MarkdownDocument {
   relativePath: string;
   content: string;


### PR DESCRIPTION
## Summary
- stream initial markdown discovery through a dedicated scan progress event
- accumulate discovered files in the frontend store without replacing the tree wholesale
- surface scan progress, skipped paths, and scan errors in the document tree UI

## Verification
- pnpm typecheck
- cargo check (src-tauri)
- pnpm build

Closes #5