### PR TITLE
Add markdown editing and save flow

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -184,6 +184,64 @@ fn read_markdown_file(
     })
 }
 
+#[tauri::command]
+fn write_markdown_file(
+    relative_path: String,
+    content: String,
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, AppState>,
+) -> Result<MarkdownDocument, String> {
+    let sessions = state
+        .sessions
+        .lock()
+        .map_err(|_| "failed to acquire sessions lock".to_string())?;
+
+    let session = sessions
+        .get(window.label())
+        .ok_or_else(|| format!("no session for window {}", window.label()))?;
+
+    if !session.files.iter().any(|entry| entry == &relative_path) {
+        return Err(format!(
+            "document is not available in the current root: {}",
+            relative_path
+        ));
+    }
+
+    let file_path = session.root_dir.join(&relative_path);
+    let canonical_parent = file_path
+        .parent()
+        .ok_or_else(|| format!("failed to resolve parent for {}", file_path.display()))?
+        .canonicalize()
+        .map_err(|error| {
+            format!(
+                "failed to resolve parent for {}: {}",
+                file_path.display(),
+                error
+            )
+        })?;
+
+    if !canonical_parent.starts_with(&session.root_dir) {
+        return Err(format!(
+            "document is outside the current root: {}",
+            relative_path
+        ));
+    }
+
+    fs::write(&file_path, &content).map_err(|error| {
+        format!(
+            "failed to write markdown file {}: {}",
+            file_path.display(),
+            error
+        )
+    })?;
+
+    Ok(MarkdownDocument {
+        relative_path,
+        headings: extract_headings(&content),
+        content,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Application entry point
 // ---------------------------------------------------------------------------
@@ -236,7 +294,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             get_initial_session,
             refresh_session,
-            read_markdown_file
+            read_markdown_file,
+            write_markdown_file
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { FileText, FolderTree, Menu, RefreshCcw, TextSearch } from "lucide-react";
+import { Edit3, Eye, FileText, FolderTree, Menu, RefreshCcw, Save, TextSearch } from "lucide-react";
 
 import { FileTree } from "@/components/file-tree";
 import { MarkdownView } from "@/components/markdown-view";
@@ -14,6 +14,11 @@ function App() {
   const bootstrap = useAppStore((state) => state.bootstrap);
   const openDocument = useAppStore((state) => state.openDocument);
   const refresh = useAppStore((state) => state.refresh);
+  const setDocumentMode = useAppStore((state) => state.setDocumentMode);
+  const updateDraftContent = useAppStore((state) => state.updateDraftContent);
+  const saveCurrentDocument = useAppStore((state) => state.saveCurrentDocument);
+  const reloadCurrentDocument = useAppStore((state) => state.reloadCurrentDocument);
+  const keepDraftAfterExternalChange = useAppStore((state) => state.keepDraftAfterExternalChange);
   const bootstrapState = useAppStore((state) => state.bootstrapState);
   const error = useAppStore((state) => state.error);
   const rootDir = useAppStore((state) => state.rootDir);
@@ -43,6 +48,18 @@ function App() {
       void unlistenPromise.then((unlisten) => unlisten());
     };
   }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+        event.preventDefault();
+        void saveCurrentDocument();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [saveCurrentDocument]);
 
   const selectedSegments = selectedFile?.split("/") ?? [];
   const selectedLabel = selectedSegments[selectedSegments.length - 1] ?? "문서를 선택하세요";
@@ -121,12 +138,59 @@ function App() {
               <Card className="min-h-[70vh] overflow-hidden">
                 <CardContent className="flex h-full flex-col p-0">
                   <div className="border-b border-border/60 px-5 py-4">
-                    <div className="flex items-center gap-2 text-sm font-medium uppercase tracking-widest text-muted-foreground">
-                      <TextSearch className="h-4 w-4" />
-                      Reader
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2 text-sm font-medium uppercase tracking-widest text-muted-foreground">
+                          <TextSearch className="h-4 w-4" />
+                          {document.mode === "edit" ? "Editor" : "Reader"}
+                          {document.isDirty ? <span className="tracking-normal text-destructive">저장 안 됨</span> : null}
+                        </div>
+                        <h1 className="mt-2 truncate font-display text-2xl font-semibold text-foreground">{selectedLabel}</h1>
+                      </div>
+                      {document.state === "ready" ? (
+                        <div className="flex shrink-0 items-center gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setDocumentMode(document.mode === "edit" ? "preview" : "edit")}
+                          >
+                            {document.mode === "edit" ? <Eye className="h-4 w-4" /> : <Edit3 className="h-4 w-4" />}
+                            {document.mode === "edit" ? "미리보기" : "편집"}
+                          </Button>
+                          <Button
+                            size="sm"
+                            disabled={!document.isDirty || document.isSaving}
+                            onClick={() => void saveCurrentDocument()}
+                          >
+                            <Save className="h-4 w-4" />
+                            {document.isSaving ? "저장 중" : "저장"}
+                          </Button>
+                        </div>
+                      ) : null}
                     </div>
-                    <h1 className="mt-2 truncate font-display text-2xl font-semibold text-foreground">{selectedLabel}</h1>
                   </div>
+
+                  {document.externalChangeDetected ? (
+                    <div className="border-b border-border/60 bg-secondary px-5 py-3 text-sm text-secondary-foreground">
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <span>파일이 디스크에서 변경되었습니다.</span>
+                        <div className="flex items-center gap-2">
+                          <Button variant="outline" size="sm" onClick={() => void reloadCurrentDocument(true)}>
+                            디스크에서 다시 불러오기
+                          </Button>
+                          <Button variant="ghost" size="sm" onClick={keepDraftAfterExternalChange}>
+                            현재 편집 유지
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {document.state === "ready" && document.error ? (
+                    <div className="border-b border-destructive/30 bg-destructive/10 px-5 py-3 text-sm text-destructive">
+                      {document.error}
+                    </div>
+                  ) : null}
 
                   {document.state === "loading" ? (
                     <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
@@ -136,6 +200,8 @@ function App() {
                     <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-destructive">
                       {document.error}
                     </div>
+                  ) : document.content && document.mode === "edit" ? (
+                    <MarkdownEditor content={document.draftContent} onChange={updateDraftContent} />
                   ) : document.content ? (
                     <MarkdownView
                       content={document.content}
@@ -163,6 +229,19 @@ function App() {
           </div>
         )}
       </main>
+    </div>
+  );
+}
+
+function MarkdownEditor({ content, onChange }: { content: string; onChange: (content: string) => void }) {
+  return (
+    <div className="h-[calc(100vh-13rem)] bg-background">
+      <textarea
+        value={content}
+        onChange={(event) => onChange(event.target.value)}
+        spellCheck={false}
+        className="h-full w-full resize-none border-0 bg-background px-5 py-6 font-mono text-sm leading-7 text-foreground outline-none placeholder:text-muted-foreground focus:ring-0 sm:px-8"
+      />
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,11 @@ function App() {
   const document = useAppStore((state) => state.document);
   const isSidebarOpen = useAppStore((state) => state.isSidebarOpen);
   const setSidebarOpen = useAppStore((state) => state.setSidebarOpen);
+  const canSaveDocument =
+    document.state === "ready" &&
+    document.isDirty &&
+    !document.isSaving &&
+    !document.externalChangeDetected;
 
   useEffect(() => {
     void bootstrap();
@@ -53,13 +58,15 @@ function App() {
     const handleKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
         event.preventDefault();
-        void saveCurrentDocument();
+        if (canSaveDocument) {
+          void saveCurrentDocument();
+        }
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [saveCurrentDocument]);
+  }, [canSaveDocument, saveCurrentDocument]);
 
   const selectedSegments = selectedFile?.split("/") ?? [];
   const selectedLabel = selectedSegments[selectedSegments.length - 1] ?? "문서를 선택하세요";
@@ -159,7 +166,7 @@ function App() {
                           </Button>
                           <Button
                             size="sm"
-                            disabled={!document.isDirty || document.isSaving}
+                            disabled={!canSaveDocument}
                             onClick={() => void saveCurrentDocument()}
                           >
                             <Save className="h-4 w-4" />
@@ -200,9 +207,9 @@ function App() {
                     <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-destructive">
                       {document.error}
                     </div>
-                  ) : document.content && document.mode === "edit" ? (
+                  ) : document.state === "ready" && document.mode === "edit" ? (
                     <MarkdownEditor content={document.draftContent} onChange={updateDraftContent} />
-                  ) : document.content ? (
+                  ) : document.state === "ready" ? (
                     <MarkdownView
                       content={document.content}
                       currentRelativePath={selectedFile}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -31,6 +31,10 @@ export function readMarkdownFile(relativePath: string) {
   return invoke<MarkdownDocument>("read_markdown_file", { relativePath });
 }
 
+export function writeMarkdownFile(relativePath: string, content: string) {
+  return invoke<MarkdownDocument>("write_markdown_file", { relativePath, content });
+}
+
 export function listenToFsChanges(handler: (payload: FsChangePayload) => void): Promise<UnlistenFn> {
   return listen<FsChangePayload>(FS_CHANGE_EVENT, (event) => handler(event.payload));
 }

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -1,11 +1,18 @@
 import { create } from "zustand";
 
 import { extractHeadings } from "@/lib/markdown";
-import { getInitialSession, readMarkdownFile, refreshSession, type ScanProgressPayload } from "@/lib/tauri";
+import {
+  getInitialSession,
+  readMarkdownFile,
+  refreshSession,
+  writeMarkdownFile,
+  type ScanProgressPayload,
+} from "@/lib/tauri";
 import type { HeadingItem, ScanStatus } from "@/types/content";
 
 type BootstrapState = "idle" | "loading" | "ready" | "error";
 type DocumentState = "idle" | "loading" | "ready" | "error";
+type DocumentMode = "preview" | "edit";
 
 interface AppStore {
   bootstrapState: BootstrapState;
@@ -22,14 +29,25 @@ interface AppStore {
   document: {
     state: DocumentState;
     content: string;
+    savedContent: string;
+    draftContent: string;
     headings: HeadingItem[];
     error: string | null;
+    mode: DocumentMode;
+    isDirty: boolean;
+    isSaving: boolean;
+    lastSavedAt: string | null;
+    externalChangeDetected: boolean;
   };
   setSidebarOpen: (open: boolean) => void;
   applyScanProgress: (payload: ScanProgressPayload) => Promise<void>;
   bootstrap: () => Promise<void>;
   openDocument: (relativePath: string) => Promise<void>;
-  reloadCurrentDocument: () => Promise<void>;
+  setDocumentMode: (mode: DocumentMode) => void;
+  updateDraftContent: (content: string) => void;
+  saveCurrentDocument: () => Promise<void>;
+  reloadCurrentDocument: (force?: boolean) => Promise<void>;
+  keepDraftAfterExternalChange: () => void;
   refresh: () => Promise<void>;
 }
 
@@ -45,12 +63,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   scanError: null,
   selectedFile: null,
   isSidebarOpen: false,
-  document: {
-    state: "idle",
-    content: "",
-    headings: [],
-    error: null,
-  },
+  document: createEmptyDocument(),
   setSidebarOpen: (open) => set({ isSidebarOpen: open }),
   applyScanProgress: async (payload) => {
     const state = get();
@@ -92,12 +105,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       scanSkippedPaths: [],
       scanSkippedPathSet: new Set(),
       scanError: null,
-      document: {
-        state: "idle",
-        content: "",
-        headings: [],
-        error: null,
-      },
+      document: createEmptyDocument(),
     });
 
     try {
@@ -122,69 +130,134 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }
   },
   openDocument: async (relativePath) => {
+    const current = get();
+    if (current.document.isDirty && !confirmDiscardUnsavedChanges()) {
+      return;
+    }
+
     set({
       selectedFile: relativePath,
-      document: {
-        state: "loading",
-        content: "",
-        headings: [],
-        error: null,
-      },
+      document: createLoadingDocument(),
     });
 
     try {
       const document = await readMarkdownFile(relativePath);
       set({
         selectedFile: document.relativePath,
-        document: {
-          state: "ready",
-          content: document.content,
-          headings: document.headings.length > 0 ? document.headings : extractHeadings(document.content),
-          error: null,
-        },
+        document: createReadyDocument(document.content, document.headings),
       });
     } catch (error) {
       set({
-        document: {
-          state: "error",
-          content: "",
-          headings: [],
-          error: error instanceof Error ? error.message : "문서를 열지 못했습니다.",
-        },
+        document: createErrorDocument(error instanceof Error ? error.message : "문서를 열지 못했습니다."),
       });
     }
   },
-  reloadCurrentDocument: async () => {
+  setDocumentMode: (mode) => {
+    set((state) => ({
+      document: {
+        ...state.document,
+        mode,
+      },
+    }));
+  },
+  updateDraftContent: (content) => {
+    set((state) => ({
+      document: {
+        ...state.document,
+        content,
+        draftContent: content,
+        headings: extractHeadings(content),
+        isDirty: content !== state.document.savedContent,
+      },
+    }));
+  },
+  saveCurrentDocument: async () => {
     const current = get().selectedFile;
     if (!current) {
       return;
     }
 
+    const draftContent = get().document.draftContent;
+    set((state) => ({
+      document: {
+        ...state.document,
+        isSaving: true,
+        error: null,
+      },
+    }));
+
     try {
-      const document = await readMarkdownFile(current);
+      const document = await writeMarkdownFile(current, draftContent);
       set({
         selectedFile: document.relativePath,
         document: {
-          state: "ready",
-          content: document.content,
-          headings:
-            document.headings.length > 0 ? document.headings : extractHeadings(document.content),
-          error: null,
+          ...createReadyDocument(document.content, document.headings),
+          mode: get().document.mode,
+          lastSavedAt: new Date().toISOString(),
         },
       });
     } catch (error) {
+      set((state) => ({
+        document: {
+          ...state.document,
+          state: state.document.state === "loading" ? "error" : state.document.state,
+          isSaving: false,
+          error: error instanceof Error ? error.message : "문서를 저장하지 못했습니다.",
+        },
+      }));
+    }
+  },
+  reloadCurrentDocument: async (force = false) => {
+    const current = get().selectedFile;
+    if (!current) {
+      return;
+    }
+
+    const currentDocument = get().document;
+    if (currentDocument.isDirty && !force) {
       set({
         document: {
-          state: "error",
-          content: "",
-          headings: [],
-          error: error instanceof Error ? error.message : "문서를 다시 불러오지 못했습니다.",
+          ...currentDocument,
+          externalChangeDetected: true,
         },
+      });
+      return;
+    }
+
+    try {
+      const document = await readMarkdownFile(current);
+      set((state) => ({
+        selectedFile: document.relativePath,
+        document: {
+          ...createReadyDocument(document.content, document.headings),
+          mode: state.document.mode,
+        },
+      }));
+    } catch (error) {
+      set({
+        document: createErrorDocument(error instanceof Error ? error.message : "문서를 다시 불러오지 못했습니다."),
       });
     }
   },
+  keepDraftAfterExternalChange: () => {
+    set((state) => ({
+      document: {
+        ...state.document,
+        externalChangeDetected: false,
+      },
+    }));
+  },
   refresh: async () => {
     const previousSelection = get().selectedFile;
+    const hadDirtyDocument = get().document.isDirty;
+
+    if (hadDirtyDocument && !confirmDiscardUnsavedChanges()) {
+      return;
+    }
+
+    if (hadDirtyDocument) {
+      set({ document: createEmptyDocument() });
+    }
 
     try {
       const session = await refreshSession();
@@ -211,12 +284,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       } else {
         set({
           selectedFile: null,
-          document: {
-            state: "idle",
-            content: "",
-            headings: [],
-            error: null,
-          },
+          document: createEmptyDocument(),
         });
       }
     } catch (error) {
@@ -226,6 +294,57 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }
   },
 }));
+
+function createEmptyDocument(): AppStore["document"] {
+  return {
+    state: "idle",
+    content: "",
+    savedContent: "",
+    draftContent: "",
+    headings: [],
+    error: null,
+    mode: "preview",
+    isDirty: false,
+    isSaving: false,
+    lastSavedAt: null,
+    externalChangeDetected: false,
+  };
+}
+
+function createLoadingDocument(): AppStore["document"] {
+  return {
+    ...createEmptyDocument(),
+    state: "loading",
+  };
+}
+
+function createReadyDocument(content: string, headings: HeadingItem[]): AppStore["document"] {
+  return {
+    state: "ready",
+    content,
+    savedContent: content,
+    draftContent: content,
+    headings: headings.length > 0 ? headings : extractHeadings(content),
+    error: null,
+    mode: "preview",
+    isDirty: false,
+    isSaving: false,
+    lastSavedAt: null,
+    externalChangeDetected: false,
+  };
+}
+
+function createErrorDocument(message: string): AppStore["document"] {
+  return {
+    ...createEmptyDocument(),
+    state: "error",
+    error: message,
+  };
+}
+
+function confirmDiscardUnsavedChanges() {
+  return window.confirm("저장하지 않은 변경사항이 있습니다. 변경사항을 버리고 계속할까요?");
+}
 
 function mergeSortedUnique(current: string[], currentSet: ReadonlySet<string>, incoming: string[]) {
   let hasNewValue = false;

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -172,12 +172,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }));
   },
   saveCurrentDocument: async () => {
-    const current = get().selectedFile;
-    if (!current) {
+    const state = get();
+    const current = state.selectedFile;
+    const currentDocument = state.document;
+    if (
+      !current ||
+      currentDocument.state !== "ready" ||
+      !currentDocument.isDirty ||
+      currentDocument.isSaving ||
+      currentDocument.externalChangeDetected
+    ) {
       return;
     }
 
-    const draftContent = get().document.draftContent;
+    const draftContent = currentDocument.draftContent;
     set((state) => ({
       document: {
         ...state.document,


### PR DESCRIPTION
## Summary
- add a Tauri write command for existing markdown documents
- introduce saved/draft document state with dirty tracking and save lifecycle
- add edit/preview controls, textarea editing, Cmd/Ctrl+S save, and external-change handling

## Verification
- pnpm typecheck
- cargo check (src-tauri)
- pnpm build

Stacked on #9 because the watcher and scan event lifecycle from #5 is the base for safe edit conflict handling.

Closes #8