### PR TITLE
Tune Vite chunk splitting

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,4 +36,34 @@ export default defineConfig(async () => ({
       ignored: ["**/src-tauri/**"],
     },
   },
+  build: {
+    chunkSizeWarningLimit: 700,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes("node_modules")) {
+            return undefined;
+          }
+
+          if (id.includes("/react-markdown/") || id.includes("/remark-gfm/") || id.includes("/rehype-highlight/")) {
+            return "markdown-renderer";
+          }
+
+          if (id.includes("/react/") || id.includes("/react-dom/")) {
+            return "react-vendor";
+          }
+
+          if (id.includes("/@tauri-apps/")) {
+            return "tauri-vendor";
+          }
+
+          if (id.includes("/lucide-react/")) {
+            return "icons";
+          }
+
+          return undefined;
+        },
+      },
+    },
+  },
 }));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,8 @@ export default defineConfig(async () => ({
     },
   },
   build: {
+    // Mermaid's renderer core remains a lazy-loaded chunk, so this limit
+    // reflects render-time code rather than startup JavaScript.
     chunkSizeWarningLimit: 700,
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary
- split React, Markdown renderer, Tauri API, and icon dependencies into explicit chunks
- keep Mermaid on its existing dynamic import path instead of forcing it into the initial app bundle
- raise the warning limit to 700 kB to reflect the lazy Mermaid payload while keeping initial app chunks well below the limit

## Verification
- pnpm typecheck
- pnpm build

Build result: no Vite chunk-size warning. Initial index chunk is about 100 kB minified; Mermaid remains a lazy chunk loaded only for Mermaid rendering.

Closes #4