### PR TITLE
Guard against stale document load results

### DIFF
--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -130,6 +130,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }
   },
   openDocument: async (relativePath) => {
+    const requestPath = relativePath;
     const current = get();
     if (current.document.isDirty && !confirmDiscardUnsavedChanges()) {
       return;
@@ -141,12 +142,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
     });
 
     try {
-      const document = await readMarkdownFile(relativePath);
+      const document = await readMarkdownFile(requestPath);
+      if (get().selectedFile !== requestPath) {
+        return;
+      }
+
       set({
         selectedFile: document.relativePath,
         document: createReadyDocument(document.content, document.headings),
       });
     } catch (error) {
+      if (get().selectedFile !== requestPath) {
+        return;
+      }
+
       set({
         document: createErrorDocument(error instanceof Error ? error.message : "문서를 열지 못했습니다."),
       });
@@ -220,6 +229,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     if (!current) {
       return;
     }
+    const requestPath = current;
 
     const currentDocument = get().document;
     if (currentDocument.isDirty && !force) {
@@ -233,7 +243,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }
 
     try {
-      const document = await readMarkdownFile(current);
+      const document = await readMarkdownFile(requestPath);
+      if (get().selectedFile !== requestPath) {
+        return;
+      }
+
       set((state) => ({
         selectedFile: document.relativePath,
         document: {
@@ -242,6 +256,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
         },
       }));
     } catch (error) {
+      if (get().selectedFile !== requestPath) {
+        return;
+      }
+
       set({
         document: createErrorDocument(error instanceof Error ? error.message : "문서를 다시 불러오지 못했습니다."),
       });

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -25,6 +25,7 @@ interface AppStore {
   scanSkippedPathSet: ReadonlySet<string>;
   scanError: string | null;
   selectedFile: string | null;
+  documentLoadToken: number;
   isSidebarOpen: boolean;
   document: {
     state: DocumentState;
@@ -62,6 +63,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   scanSkippedPathSet: new Set(),
   scanError: null,
   selectedFile: null,
+  documentLoadToken: 0,
   isSidebarOpen: false,
   document: createEmptyDocument(),
   setSidebarOpen: (open) => set({ isSidebarOpen: open }),
@@ -136,14 +138,16 @@ export const useAppStore = create<AppStore>((set, get) => ({
       return;
     }
 
+    const loadToken = current.documentLoadToken + 1;
     set({
       selectedFile: relativePath,
+      documentLoadToken: loadToken,
       document: createLoadingDocument(),
     });
 
     try {
       const document = await readMarkdownFile(requestPath);
-      if (get().selectedFile !== requestPath) {
+      if (!isCurrentDocumentLoad(get(), requestPath, loadToken)) {
         return;
       }
 
@@ -152,7 +156,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         document: createReadyDocument(document.content, document.headings),
       });
     } catch (error) {
-      if (get().selectedFile !== requestPath) {
+      if (!isCurrentDocumentLoad(get(), requestPath, loadToken)) {
         return;
       }
 
@@ -230,8 +234,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
       return;
     }
     const requestPath = current;
+    const currentState = get();
 
-    const currentDocument = get().document;
+    const currentDocument = currentState.document;
     if (currentDocument.isDirty && !force) {
       set({
         document: {
@@ -242,9 +247,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
       return;
     }
 
+    const loadToken = currentState.documentLoadToken + 1;
+    set({ documentLoadToken: loadToken });
+
     try {
       const document = await readMarkdownFile(requestPath);
-      if (get().selectedFile !== requestPath) {
+      if (!isCurrentDocumentLoad(get(), requestPath, loadToken)) {
         return;
       }
 
@@ -256,7 +264,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         },
       }));
     } catch (error) {
-      if (get().selectedFile !== requestPath) {
+      if (!isCurrentDocumentLoad(get(), requestPath, loadToken)) {
         return;
       }
 
@@ -370,6 +378,10 @@ function createErrorDocument(message: string): AppStore["document"] {
 
 function confirmDiscardUnsavedChanges() {
   return window.confirm("저장하지 않은 변경사항이 있습니다. 변경사항을 버리고 계속할까요?");
+}
+
+function isCurrentDocumentLoad(state: AppStore, requestPath: string, loadToken: number) {
+  return state.selectedFile === requestPath && state.documentLoadToken === loadToken;
 }
 
 function mergeSortedUnique(current: string[], currentSet: ReadonlySet<string>, incoming: string[]) {


### PR DESCRIPTION
## Summary
- ignore async openDocument results when the selected file has changed before the read resolves
- apply the same stale-result guard to reloadCurrentDocument success and error paths
- prevent older read failures from replacing the current document state

## Verification
- pnpm typecheck
- cargo check (src-tauri)
- pnpm build

Closes #13