### PR TITLE
feat: add save-and-continue unsaved dialog action

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,13 @@ struct MarkdownDocument {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct RenameMarkdownResult {
+    old_relative_path: String,
+    document: MarkdownDocument,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct DeleteMarkdownResult {
     deleted_relative_path: String,
     next_selected_file: Option<String>,
@@ -237,6 +244,119 @@ fn write_markdown_file(
 }
 
 #[tauri::command]
+fn create_markdown_file(
+    relative_path: String,
+    content: Option<String>,
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, AppState>,
+) -> Result<MarkdownDocument, String> {
+    let mut sessions = state
+        .sessions
+        .lock()
+        .map_err(|_| "failed to acquire sessions lock".to_string())?;
+
+    let session = sessions
+        .get_mut(window.label())
+        .ok_or_else(|| format!("no session for window {}", window.label()))?;
+
+    let file_path = create_session_markdown_path(session, &relative_path)?;
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!("failed to create parent directory {}: {}", parent.display(), error)
+        })?;
+    }
+
+    let content = content.unwrap_or_default();
+    fs::write(&file_path, &content)
+        .map_err(|error| format!("failed to create markdown file {}: {}", file_path.display(), error))?;
+
+    if !session.files.iter().any(|entry| entry == &relative_path) {
+        session.files.push(relative_path.clone());
+        session.files.sort();
+    }
+    session.selected_file = Some(relative_path.clone());
+
+    Ok(MarkdownDocument {
+        relative_path,
+        headings: extract_headings(&content),
+        content,
+    })
+}
+
+#[tauri::command]
+fn rename_markdown_file(
+    from_relative_path: String,
+    to_relative_path: String,
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, AppState>,
+) -> Result<RenameMarkdownResult, String> {
+    let mut sessions = state
+        .sessions
+        .lock()
+        .map_err(|_| "failed to acquire sessions lock".to_string())?;
+
+    let session = sessions
+        .get_mut(window.label())
+        .ok_or_else(|| format!("no session for window {}", window.label()))?;
+
+    if !session.files.iter().any(|entry| entry == &from_relative_path) {
+        return Err(format!(
+            "document is not available in the current root: {}",
+            from_relative_path
+        ));
+    }
+
+    if from_relative_path == to_relative_path {
+        return Err("new path must be different from the current path".to_string());
+    }
+
+    let from_file_path = session.root_dir.join(&from_relative_path);
+    let canonical_from = canonical_file_inside_root(
+        &session.canonical_root_dir,
+        &from_file_path,
+        &from_relative_path,
+    )?;
+    let target_file_path = create_session_markdown_path(session, &to_relative_path)?;
+
+    if let Some(parent) = target_file_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!("failed to create parent directory {}: {}", parent.display(), error)
+        })?;
+    }
+
+    fs::rename(&canonical_from, &target_file_path).map_err(|error| {
+        format!(
+            "failed to rename markdown file {} -> {}: {}",
+            from_relative_path, to_relative_path, error
+        )
+    })?;
+
+    session.files.retain(|entry| entry != &from_relative_path);
+    session.files.push(to_relative_path.clone());
+    session.files.sort();
+    if session.selected_file.as_deref() == Some(&from_relative_path) {
+        session.selected_file = Some(to_relative_path.clone());
+    }
+
+    let content = fs::read_to_string(&target_file_path).map_err(|error| {
+        format!(
+            "failed to read renamed markdown file {}: {}",
+            target_file_path.display(),
+            error
+        )
+    })?;
+
+    Ok(RenameMarkdownResult {
+        old_relative_path: from_relative_path,
+        document: MarkdownDocument {
+            relative_path: to_relative_path,
+            headings: extract_headings(&content),
+            content,
+        },
+    })
+}
+
+#[tauri::command]
 fn delete_markdown_file(
     relative_path: String,
     window: tauri::WebviewWindow,
@@ -339,6 +459,8 @@ pub fn run() {
             refresh_session,
             read_markdown_file,
             write_markdown_file,
+            create_markdown_file,
+            rename_markdown_file,
             delete_markdown_file
         ])
         .run(tauri::generate_context!())
@@ -996,6 +1118,38 @@ fn canonical_file_inside_root(
     }
 
     Ok(canonical_file)
+}
+
+fn create_session_markdown_path(session: &SessionState, relative_path: &str) -> Result<PathBuf, String> {
+    let relative = Path::new(relative_path);
+    if relative_path.trim().is_empty()
+        || relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(format!("invalid relative markdown path: {}", relative_path));
+    }
+
+    let file_path = session.root_dir.join(relative);
+    if !is_markdown_file(&file_path) {
+        return Err(format!("document is not a markdown file: {}", relative_path));
+    }
+
+    if session.files.iter().any(|entry| entry == relative_path) || file_path.exists() {
+        return Err(format!("document already exists: {}", relative_path));
+    }
+
+    let canonical_parent = file_path
+        .parent()
+        .unwrap_or(&session.root_dir)
+        .canonicalize()
+        .unwrap_or_else(|_| session.root_dir.clone());
+    if !canonical_parent.starts_with(&session.canonical_root_dir) {
+        return Err(format!("document is outside the current root: {}", relative_path));
+    }
+
+    Ok(file_path)
 }
 
 fn path_to_relative(root_dir: &Path, path: &Path) -> Option<String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,13 @@ struct MarkdownDocument {
     headings: Vec<HeadingItem>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DeleteMarkdownResult {
+    deleted_relative_path: String,
+    next_selected_file: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 struct SessionState {
     root_dir: PathBuf,
@@ -229,6 +236,54 @@ fn write_markdown_file(
     })
 }
 
+#[tauri::command]
+fn delete_markdown_file(
+    relative_path: String,
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, AppState>,
+) -> Result<DeleteMarkdownResult, String> {
+    let mut sessions = state
+        .sessions
+        .lock()
+        .map_err(|_| "failed to acquire sessions lock".to_string())?;
+
+    let session = sessions
+        .get_mut(window.label())
+        .ok_or_else(|| format!("no session for window {}", window.label()))?;
+
+    if !session.files.iter().any(|entry| entry == &relative_path) {
+        return Err(format!(
+            "document is not available in the current root: {}",
+            relative_path
+        ));
+    }
+
+    let file_path = session.root_dir.join(&relative_path);
+    let canonical_file =
+        canonical_file_inside_root(&session.canonical_root_dir, &file_path, &relative_path)?;
+    fs::remove_file(&canonical_file).map_err(|error| {
+        format!(
+            "failed to delete markdown file {}: {}",
+            canonical_file.display(),
+            error
+        )
+    })?;
+
+    session.files.retain(|entry| entry != &relative_path);
+    let next_selected_file = if session.selected_file.as_deref() == Some(&relative_path) {
+        let next = pick_default_document(&session.files);
+        session.selected_file = next.clone();
+        next
+    } else {
+        session.selected_file.clone()
+    };
+
+    Ok(DeleteMarkdownResult {
+        deleted_relative_path: relative_path,
+        next_selected_file,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Application entry point
 // ---------------------------------------------------------------------------
@@ -283,7 +338,8 @@ pub fn run() {
             get_initial_session,
             refresh_session,
             read_markdown_file,
-            write_markdown_file
+            write_markdown_file,
+            delete_markdown_file
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,9 @@ function App() {
   const bootstrapState = useAppStore((state) => state.bootstrapState);
   const error = useAppStore((state) => state.error);
   const rootDir = useAppStore((state) => state.rootDir);
+  const successMessage = useAppStore((state) => state.successMessage);
+  const successMessageId = useAppStore((state) => state.successMessageId);
+  const clearSuccessMessage = useAppStore((state) => state.clearSuccessMessage);
   const files = useAppStore((state) => state.files);
   const scanState = useAppStore((state) => state.scanState);
   const scanSkippedPaths = useAppStore((state) => state.scanSkippedPaths);
@@ -92,6 +95,18 @@ function App() {
       setRenamePath(selectedFile ?? "");
     }
   }, [isRenameDialogOpen, selectedFile]);
+
+  useEffect(() => {
+    if (!successMessage) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      clearSuccessMessage();
+    }, 2600);
+
+    return () => window.clearTimeout(timer);
+  }, [successMessage, successMessageId, clearSuccessMessage]);
 
   const selectedSegments = selectedFile?.split("/") ?? [];
   const selectedLabel = selectedSegments[selectedSegments.length - 1] ?? "문서를 선택하세요";
@@ -327,6 +342,12 @@ function App() {
                         ) : null}
                       </div>
                     </div>
+
+                    {successMessage ? (
+                      <div className="border-b border-emerald-500/20 bg-emerald-500/10 px-5 py-3 text-sm text-emerald-700">
+                        {successMessage}
+                      </div>
+                    ) : null}
 
                     {document.externalChangeDetected ? (
                       <div className="border-b border-border/60 bg-secondary px-5 py-3 text-sm text-secondary-foreground">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Edit3, Eye, FilePenLine, FilePlus2, FileText, FolderTree, Menu, RefreshCcw, Save, TextSearch, Trash2 } from "lucide-react";
 
 import { FileTree } from "@/components/file-tree";
@@ -51,6 +52,7 @@ function App() {
   const [createPath, setCreatePath] = useState("untitled.md");
   const [renamePath, setRenamePath] = useState("");
   const [pendingUnsavedAction, setPendingUnsavedAction] = useState<PendingUnsavedAction | null>(null);
+  const allowWindowCloseRef = useRef(false);
 
   const canSaveDocument =
     document.state === "ready" &&
@@ -107,6 +109,63 @@ function App() {
 
     return () => window.clearTimeout(timer);
   }, [successMessage, successMessageId, clearSuccessMessage]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!document.isDirty || allowWindowCloseRef.current) {
+        return;
+      }
+
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [document.isDirty]);
+
+  useEffect(() => {
+    let isDisposed = false;
+    let cleanup: (() => void) | undefined;
+
+    const setupCloseGuard = async () => {
+      try {
+        const appWindow = getCurrentWindow();
+        const unlisten = await appWindow.onCloseRequested(async (event) => {
+          if (allowWindowCloseRef.current || !document.isDirty) {
+            return;
+          }
+
+          event.preventDefault();
+          setPendingUnsavedAction({
+            title: "변경사항 버리고 앱 닫기",
+            description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 창을 닫습니다.",
+            confirmLabel: "버리고 닫기",
+            run: async () => {
+              allowWindowCloseRef.current = true;
+              await appWindow.close();
+            },
+          });
+        });
+
+        if (isDisposed) {
+          unlisten();
+          return;
+        }
+
+        cleanup = unlisten;
+      } catch {
+        // non-tauri surface
+      }
+    };
+
+    void setupCloseGuard();
+
+    return () => {
+      isDisposed = true;
+      cleanup?.();
+    };
+  }, [document.isDirty]);
 
   const selectedSegments = selectedFile?.split("/") ?? [];
   const selectedLabel = selectedSegments[selectedSegments.length - 1] ?? "문서를 선택하세요";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,13 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/co
 import { useAppStore } from "@/store/app-store";
 import { subscribeToFsChanges, subscribeToScanProgress } from "@/store/fs-watcher";
 
+type PendingUnsavedAction = {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  run: () => Promise<void> | void;
+};
+
 function App() {
   const bootstrap = useAppStore((state) => state.bootstrap);
   const openDocument = useAppStore((state) => state.openDocument);
@@ -40,6 +47,7 @@ function App() {
   const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [createPath, setCreatePath] = useState("untitled.md");
   const [renamePath, setRenamePath] = useState("");
+  const [pendingUnsavedAction, setPendingUnsavedAction] = useState<PendingUnsavedAction | null>(null);
 
   const canSaveDocument =
     document.state === "ready" &&
@@ -94,30 +102,115 @@ function App() {
     return `"${selectedFile}" 문서를 삭제합니다. 삭제 후에는 복구되지 않습니다.`;
   }, [selectedFile]);
 
-  const handleCreateDocument = async () => {
+  const runGuardedAction = (action: PendingUnsavedAction) => {
+    if (document.isDirty) {
+      setPendingUnsavedAction(action);
+      return;
+    }
+
+    void action.run();
+  };
+
+  const handleOpenDocument = (file: string) => {
+    if (file === selectedFile) {
+      return;
+    }
+
+    runGuardedAction({
+      title: "변경사항 버리고 다른 문서 열기",
+      description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 편집 중인 내용이 사라지고 선택한 문서를 엽니다.",
+      confirmLabel: "버리고 열기",
+      run: async () => {
+        await openDocument(file);
+        setSidebarOpen(false);
+      },
+    });
+  };
+
+  const handleRefresh = () => {
+    runGuardedAction({
+      title: "변경사항 버리고 새로고침",
+      description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 디스크 기준 상태로 세션을 새로고침합니다.",
+      confirmLabel: "버리고 새로고침",
+      run: refresh,
+    });
+  };
+
+  const handleReloadFromDisk = () => {
+    runGuardedAction({
+      title: "변경사항 버리고 다시 불러오기",
+      description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 파일을 디스크 상태로 다시 불러옵니다.",
+      confirmLabel: "디스크에서 다시 불러오기",
+      run: async () => {
+        await reloadCurrentDocument(true);
+      },
+    });
+  };
+
+  const handleCreateDocument = () => {
     const nextPath = createPath.trim();
     if (!nextPath) {
       return;
     }
 
-    await createDocument(nextPath, "");
-    setCreateDialogOpen(false);
-    setCreatePath("untitled.md");
+    const execute = async () => {
+      await createDocument(nextPath, "");
+      setCreateDialogOpen(false);
+      setCreatePath("untitled.md");
+    };
+
+    if (document.isDirty) {
+      setCreateDialogOpen(false);
+      setPendingUnsavedAction({
+        title: "변경사항 버리고 새 문서 생성",
+        description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 새 문서를 생성해 엽니다.",
+        confirmLabel: "버리고 생성",
+        run: execute,
+      });
+      return;
+    }
+
+    void execute();
   };
 
-  const handleRenameDocument = async () => {
+  const handleRenameDocument = () => {
     const nextPath = renamePath.trim();
     if (!nextPath || !selectedFile) {
       return;
     }
 
-    await renameCurrentDocument(nextPath);
-    setRenameDialogOpen(false);
+    const execute = async () => {
+      await renameCurrentDocument(nextPath);
+      setRenameDialogOpen(false);
+    };
+
+    if (document.isDirty) {
+      setRenameDialogOpen(false);
+      setPendingUnsavedAction({
+        title: "변경사항 버리고 문서 이름 변경",
+        description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 저장된 파일 기준으로 이름을 변경합니다.",
+        confirmLabel: "버리고 변경",
+        run: execute,
+      });
+      return;
+    }
+
+    void execute();
   };
 
   const handleDeleteDocument = async () => {
     await deleteCurrentDocument();
     setDeleteDialogOpen(false);
+  };
+
+  const handleConfirmPendingUnsavedAction = async () => {
+    if (!pendingUnsavedAction) {
+      return;
+    }
+
+    const action = pendingUnsavedAction;
+    setPendingUnsavedAction(null);
+    await action.run();
   };
 
   return (
@@ -156,10 +249,7 @@ function App() {
                         scanState={scanState}
                         skippedCount={scanSkippedPaths.length}
                         selectedFile={selectedFile}
-                        onSelect={(file) => {
-                          void openDocument(file);
-                          setSidebarOpen(false);
-                        }}
+                        onSelect={handleOpenDocument}
                       />
                     </div>
                   </SheetContent>
@@ -180,7 +270,7 @@ function App() {
                   삭제
                 </Button>
 
-                <Button variant="outline" size="sm" onClick={() => void refresh()}>
+                <Button variant="outline" size="sm" onClick={handleRefresh}>
                   <RefreshCcw className="mr-2 h-4 w-4" />
                   새로고침
                 </Button>
@@ -201,7 +291,7 @@ function App() {
                     scanState={scanState}
                     skippedCount={scanSkippedPaths.length}
                     selectedFile={selectedFile}
-                    onSelect={(file) => void openDocument(file)}
+                    onSelect={handleOpenDocument}
                   />
                 </div>
               </aside>
@@ -243,7 +333,7 @@ function App() {
                         <div className="flex flex-wrap items-center justify-between gap-3">
                           <span>파일이 디스크에서 변경되었습니다.</span>
                           <div className="flex items-center gap-2">
-                            <Button variant="outline" size="sm" onClick={() => void reloadCurrentDocument(true)}>
+                            <Button variant="outline" size="sm" onClick={handleReloadFromDisk}>
                               디스크에서 다시 불러오기
                             </Button>
                             <Button variant="ghost" size="sm" onClick={keepDraftAfterExternalChange}>
@@ -273,7 +363,7 @@ function App() {
                         content={document.content}
                         currentRelativePath={selectedFile}
                         knownDocuments={files}
-                        onNavigate={openDocument}
+                        onNavigate={(path) => handleOpenDocument(path)}
                       />
                     ) : (
                       <EmptyReader />
@@ -306,7 +396,7 @@ function App() {
         onValueChange={setCreatePath}
         placeholder="untitled.md"
         confirmLabel="생성"
-        onConfirm={() => void handleCreateDocument()}
+        onConfirm={handleCreateDocument}
       />
 
       <FileActionDialog
@@ -318,7 +408,7 @@ function App() {
         onValueChange={setRenamePath}
         placeholder="docs/renamed.md"
         confirmLabel="변경"
-        onConfirm={() => void handleRenameDocument()}
+        onConfirm={handleRenameDocument}
       />
 
       <Dialog open={isDeleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
@@ -333,6 +423,25 @@ function App() {
             </Button>
             <Button disabled={!selectedFile} onClick={() => void handleDeleteDocument()}>
               삭제
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={pendingUnsavedAction !== null} onOpenChange={(open) => !open && setPendingUnsavedAction(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{pendingUnsavedAction?.title ?? "저장되지 않은 변경사항"}</DialogTitle>
+            <DialogDescription>
+              {pendingUnsavedAction?.description ?? "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft가 사라집니다."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingUnsavedAction(null)}>
+              취소
+            </Button>
+            <Button onClick={() => void handleConfirmPendingUnsavedAction()}>
+              {pendingUnsavedAction?.confirmLabel ?? "계속"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -287,6 +287,23 @@ function App() {
     await action.run();
   };
 
+  const handleSaveAndContinuePendingAction = async () => {
+    if (!pendingUnsavedAction) {
+      return;
+    }
+
+    await saveCurrentDocument();
+
+    const latestDocument = useAppStore.getState().document;
+    if (latestDocument.isDirty || latestDocument.error) {
+      return;
+    }
+
+    const action = pendingUnsavedAction;
+    setPendingUnsavedAction(null);
+    await action.run();
+  };
+
   return (
     <>
       <div className="min-h-screen bg-background text-foreground">
@@ -519,6 +536,9 @@ function App() {
           <DialogFooter>
             <Button variant="outline" onClick={() => setPendingUnsavedAction(null)}>
               취소
+            </Button>
+            <Button variant="outline" disabled={!canSaveDocument} onClick={() => void handleSaveAndContinuePendingAction()}>
+              {document.isSaving ? "저장 중" : "저장 후 계속"}
             </Button>
             <Button onClick={() => void handleConfirmPendingUnsavedAction()}>
               {pendingUnsavedAction?.confirmLabel ?? "계속"}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Edit3, Eye, FileText, FolderTree, Menu, RefreshCcw, Save, TextSearch } from "lucide-react";
+import { Edit3, Eye, FileText, FolderTree, Menu, RefreshCcw, Save, TextSearch, Trash2 } from "lucide-react";
 
 import { FileTree } from "@/components/file-tree";
 import { MarkdownView } from "@/components/markdown-view";
@@ -13,6 +13,7 @@ import { subscribeToFsChanges, subscribeToScanProgress } from "@/store/fs-watche
 function App() {
   const bootstrap = useAppStore((state) => state.bootstrap);
   const openDocument = useAppStore((state) => state.openDocument);
+  const deleteCurrentDocument = useAppStore((state) => state.deleteCurrentDocument);
   const refresh = useAppStore((state) => state.refresh);
   const setDocumentMode = useAppStore((state) => state.setDocumentMode);
   const updateDraftContent = useAppStore((state) => state.updateDraftContent);
@@ -114,6 +115,11 @@ function App() {
                   </div>
                 </SheetContent>
               </Sheet>
+
+              <Button variant="outline" size="sm" disabled={!selectedFile} onClick={() => void deleteCurrentDocument()}>
+                <Trash2 className="mr-2 h-4 w-4" />
+                삭제
+              </Button>
 
               <Button variant="outline" size="sm" onClick={() => void refresh()}>
                 <RefreshCcw className="mr-2 h-4 w-4" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
-import { useEffect } from "react";
-import { Edit3, Eye, FileText, FolderTree, Menu, RefreshCcw, Save, TextSearch, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Edit3, Eye, FilePenLine, FilePlus2, FileText, FolderTree, Menu, RefreshCcw, Save, TextSearch, Trash2 } from "lucide-react";
 
 import { FileTree } from "@/components/file-tree";
 import { MarkdownView } from "@/components/markdown-view";
 import { TableOfContents } from "@/components/table-of-contents";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { useAppStore } from "@/store/app-store";
 import { subscribeToFsChanges, subscribeToScanProgress } from "@/store/fs-watcher";
@@ -13,6 +14,8 @@ import { subscribeToFsChanges, subscribeToScanProgress } from "@/store/fs-watche
 function App() {
   const bootstrap = useAppStore((state) => state.bootstrap);
   const openDocument = useAppStore((state) => state.openDocument);
+  const createDocument = useAppStore((state) => state.createDocument);
+  const renameCurrentDocument = useAppStore((state) => state.renameCurrentDocument);
   const deleteCurrentDocument = useAppStore((state) => state.deleteCurrentDocument);
   const refresh = useAppStore((state) => state.refresh);
   const setDocumentMode = useAppStore((state) => state.setDocumentMode);
@@ -31,6 +34,13 @@ function App() {
   const document = useAppStore((state) => state.document);
   const isSidebarOpen = useAppStore((state) => state.isSidebarOpen);
   const setSidebarOpen = useAppStore((state) => state.setSidebarOpen);
+
+  const [isCreateDialogOpen, setCreateDialogOpen] = useState(false);
+  const [isRenameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [createPath, setCreatePath] = useState("untitled.md");
+  const [renamePath, setRenamePath] = useState("");
+
   const canSaveDocument =
     document.state === "ready" &&
     document.isDirty &&
@@ -69,180 +79,325 @@ function App() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [canSaveDocument, saveCurrentDocument]);
 
+  useEffect(() => {
+    if (isRenameDialogOpen) {
+      setRenamePath(selectedFile ?? "");
+    }
+  }, [isRenameDialogOpen, selectedFile]);
+
   const selectedSegments = selectedFile?.split("/") ?? [];
   const selectedLabel = selectedSegments[selectedSegments.length - 1] ?? "문서를 선택하세요";
+  const deleteDescription = useMemo(() => {
+    if (!selectedFile) {
+      return "선택된 문서가 없습니다.";
+    }
+    return `"${selectedFile}" 문서를 삭제합니다. 삭제 후에는 복구되지 않습니다.`;
+  }, [selectedFile]);
+
+  const handleCreateDocument = async () => {
+    const nextPath = createPath.trim();
+    if (!nextPath) {
+      return;
+    }
+
+    await createDocument(nextPath, "");
+    setCreateDialogOpen(false);
+    setCreatePath("untitled.md");
+  };
+
+  const handleRenameDocument = async () => {
+    const nextPath = renamePath.trim();
+    if (!nextPath || !selectedFile) {
+      return;
+    }
+
+    await renameCurrentDocument(nextPath);
+    setRenameDialogOpen(false);
+  };
+
+  const handleDeleteDocument = async () => {
+    await deleteCurrentDocument();
+    setDeleteDialogOpen(false);
+  };
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <main className="relative mx-auto flex min-h-screen max-w-[1600px] flex-col px-4 py-4 sm:px-6">
-        <header className="mb-4 rounded-lg border border-border bg-card px-4 py-3 text-card-foreground shadow-sm">
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex min-w-0 items-center gap-3">
-              <div className="flex h-11 w-11 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-sm">
-                <FileText className="h-5 w-5" />
-              </div>
-              <div className="min-w-0">
-                <p className="font-display text-xl font-semibold text-primary">MARKMINI</p>
-                <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
-                  <span className="truncate">{rootDir ?? "루트 경로를 불러오는 중"}</span>
+    <>
+      <div className="min-h-screen bg-background text-foreground">
+        <main className="relative mx-auto flex min-h-screen max-w-[1600px] flex-col px-4 py-4 sm:px-6">
+          <header className="mb-4 rounded-lg border border-border bg-card px-4 py-3 text-card-foreground shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-3">
+                <div className="flex h-11 w-11 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-sm">
+                  <FileText className="h-5 w-5" />
+                </div>
+                <div className="min-w-0">
+                  <p className="font-display text-xl font-semibold text-primary">MARKMINI</p>
+                  <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
+                    <span className="truncate">{rootDir ?? "루트 경로를 불러오는 중"}</span>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <div className="flex items-center gap-2">
-              <Sheet open={isSidebarOpen} onOpenChange={setSidebarOpen}>
-                <SheetTrigger asChild>
-                  <Button variant="outline" size="icon" className="lg:hidden">
-                    <Menu className="h-4 w-4" />
-                    <span className="sr-only">문서 목록 열기</span>
-                  </Button>
-                </SheetTrigger>
-                <SheetContent side="left" className="w-[min(88vw,340px)] p-0">
-                  <SheetHeader className="border-b border-border/60 px-5 py-4">
-                    <SheetTitle>Documents</SheetTitle>
-                  </SheetHeader>
-                  <div className="h-[calc(100vh-72px)] overflow-hidden">
-                    <FileTree
-                      files={files}
-                      scanState={scanState}
-                      skippedCount={scanSkippedPaths.length}
-                      selectedFile={selectedFile}
-                      onSelect={(file) => {
-                        void openDocument(file);
-                        setSidebarOpen(false);
-                      }}
-                    />
-                  </div>
-                </SheetContent>
-              </Sheet>
+              <div className="flex items-center gap-2">
+                <Sheet open={isSidebarOpen} onOpenChange={setSidebarOpen}>
+                  <SheetTrigger asChild>
+                    <Button variant="outline" size="icon" className="lg:hidden">
+                      <Menu className="h-4 w-4" />
+                      <span className="sr-only">문서 목록 열기</span>
+                    </Button>
+                  </SheetTrigger>
+                  <SheetContent side="left" className="w-[min(88vw,340px)] p-0">
+                    <SheetHeader className="border-b border-border/60 px-5 py-4">
+                      <SheetTitle>Documents</SheetTitle>
+                    </SheetHeader>
+                    <div className="h-[calc(100vh-72px)] overflow-hidden">
+                      <FileTree
+                        files={files}
+                        scanState={scanState}
+                        skippedCount={scanSkippedPaths.length}
+                        selectedFile={selectedFile}
+                        onSelect={(file) => {
+                          void openDocument(file);
+                          setSidebarOpen(false);
+                        }}
+                      />
+                    </div>
+                  </SheetContent>
+                </Sheet>
 
-              <Button variant="outline" size="sm" disabled={!selectedFile} onClick={() => void deleteCurrentDocument()}>
-                <Trash2 className="mr-2 h-4 w-4" />
-                삭제
-              </Button>
+                <Button variant="outline" size="sm" onClick={() => setCreateDialogOpen(true)}>
+                  <FilePlus2 className="mr-2 h-4 w-4" />
+                  새 문서
+                </Button>
 
-              <Button variant="outline" size="sm" onClick={() => void refresh()}>
-                <RefreshCcw className="mr-2 h-4 w-4" />
-                새로고침
-              </Button>
-            </div>
-          </div>
-        </header>
+                <Button variant="outline" size="sm" disabled={!selectedFile} onClick={() => setRenameDialogOpen(true)}>
+                  <FilePenLine className="mr-2 h-4 w-4" />
+                  이름 변경
+                </Button>
 
-        {bootstrapState === "loading" ? (
-          <LoadingState />
-        ) : error ? (
-          <ErrorState message={error} onRetry={() => void bootstrap()} />
-        ) : (
-          <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[300px_minmax(0,1fr)]">
-            <aside className="hidden min-h-0 lg:block">
-              <div className="sticky top-4 h-[calc(100vh-8rem)]">
-                <FileTree
-                  files={files}
-                  scanState={scanState}
-                  skippedCount={scanSkippedPaths.length}
-                  selectedFile={selectedFile}
-                  onSelect={(file) => void openDocument(file)}
-                />
+                <Button variant="outline" size="sm" disabled={!selectedFile} onClick={() => setDeleteDialogOpen(true)}>
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  삭제
+                </Button>
+
+                <Button variant="outline" size="sm" onClick={() => void refresh()}>
+                  <RefreshCcw className="mr-2 h-4 w-4" />
+                  새로고침
+                </Button>
               </div>
-            </aside>
+            </div>
+          </header>
 
-            <section className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
-              <Card className="min-h-[70vh] overflow-hidden">
-                <CardContent className="flex h-full flex-col p-0">
-                  <div className="border-b border-border/60 px-5 py-4">
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2 text-sm font-medium uppercase tracking-widest text-muted-foreground">
-                          <TextSearch className="h-4 w-4" />
-                          {document.mode === "edit" ? "Editor" : "Reader"}
-                          {document.isDirty ? <span className="tracking-normal text-destructive">저장 안 됨</span> : null}
-                        </div>
-                        <h1 className="mt-2 truncate font-display text-2xl font-semibold text-foreground">{selectedLabel}</h1>
-                      </div>
-                      {document.state === "ready" ? (
-                        <div className="flex shrink-0 items-center gap-2">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setDocumentMode(document.mode === "edit" ? "preview" : "edit")}
-                          >
-                            {document.mode === "edit" ? <Eye className="h-4 w-4" /> : <Edit3 className="h-4 w-4" />}
-                            {document.mode === "edit" ? "미리보기" : "편집"}
-                          </Button>
-                          <Button
-                            size="sm"
-                            disabled={!canSaveDocument}
-                            onClick={() => void saveCurrentDocument()}
-                          >
-                            <Save className="h-4 w-4" />
-                            {document.isSaving ? "저장 중" : "저장"}
-                          </Button>
-                        </div>
-                      ) : null}
-                    </div>
-                  </div>
-
-                  {document.externalChangeDetected ? (
-                    <div className="border-b border-border/60 bg-secondary px-5 py-3 text-sm text-secondary-foreground">
-                      <div className="flex flex-wrap items-center justify-between gap-3">
-                        <span>파일이 디스크에서 변경되었습니다.</span>
-                        <div className="flex items-center gap-2">
-                          <Button variant="outline" size="sm" onClick={() => void reloadCurrentDocument(true)}>
-                            디스크에서 다시 불러오기
-                          </Button>
-                          <Button variant="ghost" size="sm" onClick={keepDraftAfterExternalChange}>
-                            현재 편집 유지
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  ) : null}
-
-                  {document.state === "ready" && document.error ? (
-                    <div className="border-b border-destructive/30 bg-destructive/10 px-5 py-3 text-sm text-destructive">
-                      {document.error}
-                    </div>
-                  ) : null}
-
-                  {document.state === "loading" ? (
-                    <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-                      문서를 불러오는 중입니다.
-                    </div>
-                  ) : document.state === "error" ? (
-                    <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-destructive">
-                      {document.error}
-                    </div>
-                  ) : document.state === "ready" && document.mode === "edit" ? (
-                    <MarkdownEditor content={document.draftContent} onChange={updateDraftContent} />
-                  ) : document.state === "ready" ? (
-                    <MarkdownView
-                      content={document.content}
-                      currentRelativePath={selectedFile}
-                      knownDocuments={files}
-                      onNavigate={openDocument}
-                    />
-                  ) : (
-                    <EmptyReader />
-                  )}
-                </CardContent>
-              </Card>
-
-              <aside className="min-h-0">
-                <div className="sticky top-4">
-                  {scanError ? (
-                    <div className="mb-4 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                      {scanError}
-                    </div>
-                  ) : null}
-                  <TableOfContents headings={document.headings} />
+          {bootstrapState === "loading" ? (
+            <LoadingState />
+          ) : error ? (
+            <ErrorState message={error} onRetry={() => void bootstrap()} />
+          ) : (
+            <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[300px_minmax(0,1fr)]">
+              <aside className="hidden min-h-0 lg:block">
+                <div className="sticky top-4 h-[calc(100vh-8rem)]">
+                  <FileTree
+                    files={files}
+                    scanState={scanState}
+                    skippedCount={scanSkippedPaths.length}
+                    selectedFile={selectedFile}
+                    onSelect={(file) => void openDocument(file)}
+                  />
                 </div>
               </aside>
-            </section>
-          </div>
-        )}
-      </main>
-    </div>
+
+              <section className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
+                <Card className="min-h-[70vh] overflow-hidden">
+                  <CardContent className="flex h-full flex-col p-0">
+                    <div className="border-b border-border/60 px-5 py-4">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2 text-sm font-medium uppercase tracking-widest text-muted-foreground">
+                            <TextSearch className="h-4 w-4" />
+                            {document.mode === "edit" ? "Editor" : "Reader"}
+                            {document.isDirty ? <span className="tracking-normal text-destructive">저장 안 됨</span> : null}
+                          </div>
+                          <h1 className="mt-2 truncate font-display text-2xl font-semibold text-foreground">{selectedLabel}</h1>
+                        </div>
+                        {document.state === "ready" ? (
+                          <div className="flex shrink-0 items-center gap-2">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setDocumentMode(document.mode === "edit" ? "preview" : "edit")}
+                            >
+                              {document.mode === "edit" ? <Eye className="h-4 w-4" /> : <Edit3 className="h-4 w-4" />}
+                              {document.mode === "edit" ? "미리보기" : "편집"}
+                            </Button>
+                            <Button size="sm" disabled={!canSaveDocument} onClick={() => void saveCurrentDocument()}>
+                              <Save className="h-4 w-4" />
+                              {document.isSaving ? "저장 중" : "저장"}
+                            </Button>
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+
+                    {document.externalChangeDetected ? (
+                      <div className="border-b border-border/60 bg-secondary px-5 py-3 text-sm text-secondary-foreground">
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <span>파일이 디스크에서 변경되었습니다.</span>
+                          <div className="flex items-center gap-2">
+                            <Button variant="outline" size="sm" onClick={() => void reloadCurrentDocument(true)}>
+                              디스크에서 다시 불러오기
+                            </Button>
+                            <Button variant="ghost" size="sm" onClick={keepDraftAfterExternalChange}>
+                              현재 편집 유지
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    ) : null}
+
+                    {document.state === "ready" && document.error ? (
+                      <div className="border-b border-destructive/30 bg-destructive/10 px-5 py-3 text-sm text-destructive">
+                        {document.error}
+                      </div>
+                    ) : null}
+
+                    {document.state === "loading" ? (
+                      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">문서를 불러오는 중입니다.</div>
+                    ) : document.state === "error" ? (
+                      <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-destructive">
+                        {document.error}
+                      </div>
+                    ) : document.state === "ready" && document.mode === "edit" ? (
+                      <MarkdownEditor content={document.draftContent} onChange={updateDraftContent} />
+                    ) : document.state === "ready" ? (
+                      <MarkdownView
+                        content={document.content}
+                        currentRelativePath={selectedFile}
+                        knownDocuments={files}
+                        onNavigate={openDocument}
+                      />
+                    ) : (
+                      <EmptyReader />
+                    )}
+                  </CardContent>
+                </Card>
+
+                <aside className="min-h-0">
+                  <div className="sticky top-4">
+                    {scanError ? (
+                      <div className="mb-4 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                        {scanError}
+                      </div>
+                    ) : null}
+                    <TableOfContents headings={document.headings} />
+                  </div>
+                </aside>
+              </section>
+            </div>
+          )}
+        </main>
+      </div>
+
+      <FileActionDialog
+        open={isCreateDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+        title="새 markdown 문서"
+        description="루트 기준 상대 경로를 입력하면 새 markdown 문서를 생성합니다. 예: notes/today.md"
+        value={createPath}
+        onValueChange={setCreatePath}
+        placeholder="untitled.md"
+        confirmLabel="생성"
+        onConfirm={() => void handleCreateDocument()}
+      />
+
+      <FileActionDialog
+        open={isRenameDialogOpen}
+        onOpenChange={setRenameDialogOpen}
+        title="문서 이름 변경"
+        description="현재 문서를 새 상대 경로로 이동합니다. 폴더가 없으면 함께 생성됩니다."
+        value={renamePath}
+        onValueChange={setRenamePath}
+        placeholder="docs/renamed.md"
+        confirmLabel="변경"
+        onConfirm={() => void handleRenameDocument()}
+      />
+
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>문서 삭제</DialogTitle>
+            <DialogDescription>{deleteDescription}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)}>
+              취소
+            </Button>
+            <Button disabled={!selectedFile} onClick={() => void handleDeleteDocument()}>
+              삭제
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function FileActionDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  value,
+  onValueChange,
+  placeholder,
+  confirmLabel,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  placeholder: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-2">
+          <label htmlFor={title} className="text-sm font-medium text-foreground">
+            상대 경로
+          </label>
+          <input
+            id={title}
+            value={value}
+            onChange={(event) => onValueChange(event.target.value)}
+            placeholder={placeholder}
+            autoFocus
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                onConfirm();
+              }
+            }}
+            className="h-10 rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          <Button disabled={!value.trim()} onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,83 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/50 backdrop-blur-sm", className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 grid w-[min(92vw,480px)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-border bg-card p-6 text-card-foreground shadow-xl",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+        <X className="h-4 w-4" />
+        <span className="sr-only">닫기</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col space-y-2 text-left", className)} {...props} />;
+}
+
+function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)} {...props} />;
+}
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
-import type { DeleteMarkdownResult, InitialSession, MarkdownDocument, ScanStatus } from "@/types/content";
+import type { DeleteMarkdownResult, InitialSession, MarkdownDocument, RenameMarkdownResult, ScanStatus } from "@/types/content";
 
 export interface FsChangePayload {
   changedPaths: string[];
@@ -33,6 +33,14 @@ export function readMarkdownFile(relativePath: string) {
 
 export function writeMarkdownFile(relativePath: string, content: string) {
   return invoke<MarkdownDocument>("write_markdown_file", { relativePath, content });
+}
+
+export function createMarkdownFile(relativePath: string, content = "") {
+  return invoke<MarkdownDocument>("create_markdown_file", { relativePath, content });
+}
+
+export function renameMarkdownFile(fromRelativePath: string, toRelativePath: string) {
+  return invoke<RenameMarkdownResult>("rename_markdown_file", { fromRelativePath, toRelativePath });
 }
 
 export function deleteMarkdownFile(relativePath: string) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
-import type { InitialSession, MarkdownDocument, ScanStatus } from "@/types/content";
+import type { DeleteMarkdownResult, InitialSession, MarkdownDocument, ScanStatus } from "@/types/content";
 
 export interface FsChangePayload {
   changedPaths: string[];
@@ -33,6 +33,10 @@ export function readMarkdownFile(relativePath: string) {
 
 export function writeMarkdownFile(relativePath: string, content: string) {
   return invoke<MarkdownDocument>("write_markdown_file", { relativePath, content });
+}
+
+export function deleteMarkdownFile(relativePath: string) {
+  return invoke<DeleteMarkdownResult>("delete_markdown_file", { relativePath });
 }
 
 export function listenToFsChanges(handler: (payload: FsChangePayload) => void): Promise<UnlistenFn> {

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -2,10 +2,12 @@ import { create } from "zustand";
 
 import { extractHeadings } from "@/lib/markdown";
 import {
+  createMarkdownFile,
   deleteMarkdownFile,
   getInitialSession,
   readMarkdownFile,
   refreshSession,
+  renameMarkdownFile,
   writeMarkdownFile,
   type ScanProgressPayload,
 } from "@/lib/tauri";
@@ -45,6 +47,8 @@ interface AppStore {
   applyScanProgress: (payload: ScanProgressPayload) => Promise<void>;
   bootstrap: () => Promise<void>;
   openDocument: (relativePath: string) => Promise<void>;
+  createDocument: (relativePath: string, content?: string) => Promise<void>;
+  renameCurrentDocument: (toRelativePath: string) => Promise<void>;
   deleteCurrentDocument: () => Promise<void>;
   setDocumentMode: (mode: DocumentMode) => void;
   updateDraftContent: (content: string) => void;
@@ -71,11 +75,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setSidebarOpen: (open) => set({ isSidebarOpen: open }),
   applyScanProgress: async (payload) => {
     const state = get();
-    const { values: files, valueSet: fileSet } = mergeSortedUnique(
-      state.files,
-      state.fileSet,
-      payload.files,
-    );
+    const { values: files, valueSet: fileSet } = mergeSortedUnique(state.files, state.fileSet, payload.files);
     const { values: scanSkippedPaths, valueSet: scanSkippedPathSet } = mergeSortedUnique(
       state.scanSkippedPaths,
       state.scanSkippedPathSet,
@@ -167,13 +167,82 @@ export const useAppStore = create<AppStore>((set, get) => ({
       });
     }
   },
-  deleteCurrentDocument: async () => {
+  createDocument: async (relativePath, content = "") => {
+    const state = get();
+    if (state.document.isDirty && !confirmDiscardUnsavedChanges()) {
+      return;
+    }
+
+    const normalizedPath = normalizeRelativeMarkdownPath(relativePath);
+    if (!normalizedPath) {
+      return;
+    }
+
+    set({
+      error: null,
+      selectedFile: normalizedPath,
+      document: createLoadingDocument(),
+    });
+
+    try {
+      const document = await createMarkdownFile(normalizedPath, content);
+      const { values: files, valueSet: fileSet } = mergeSortedUnique(state.files, state.fileSet, [document.relativePath]);
+      set({
+        files,
+        fileSet,
+        selectedFile: document.relativePath,
+        document: {
+          ...createReadyDocument(document.content, document.headings),
+          mode: "edit",
+        },
+      });
+    } catch (error) {
+      set({
+        selectedFile: state.selectedFile,
+        document: createErrorDocument(error instanceof Error ? error.message : "문서를 생성하지 못했습니다."),
+      });
+    }
+  },
+  renameCurrentDocument: async (toRelativePath) => {
     const state = get();
     const current = state.selectedFile;
     if (!current) {
       return;
     }
-    if (!window.confirm(`정말로 \"${current}\" 문서를 삭제할까요?`)) {
+    if (state.document.isDirty && !confirmDiscardUnsavedChanges()) {
+      return;
+    }
+
+    const normalizedPath = normalizeRelativeMarkdownPath(toRelativePath);
+    if (!normalizedPath) {
+      return;
+    }
+
+    set({ document: createLoadingDocument() });
+
+    try {
+      const result = await renameMarkdownFile(current, normalizedPath);
+      const files = state.files
+        .filter((entry) => entry !== result.oldRelativePath)
+        .concat(result.document.relativePath)
+        .sort((a, b) => a.localeCompare(b));
+      set({
+        files,
+        fileSet: new Set(files),
+        selectedFile: result.document.relativePath,
+        document: createReadyDocument(result.document.content, result.document.headings),
+      });
+    } catch (error) {
+      set({
+        selectedFile: current,
+        document: createErrorDocument(error instanceof Error ? error.message : "문서 이름을 변경하지 못했습니다."),
+      });
+    }
+  },
+  deleteCurrentDocument: async () => {
+    const state = get();
+    const current = state.selectedFile;
+    if (!current) {
       return;
     }
 
@@ -419,6 +488,10 @@ function createErrorDocument(message: string): AppStore["document"] {
 
 function confirmDiscardUnsavedChanges() {
   return window.confirm("저장하지 않은 변경사항이 있습니다. 변경사항을 버리고 계속할까요?");
+}
+
+function normalizeRelativeMarkdownPath(relativePath: string) {
+  return relativePath.trim().replace(/^\/+/, "");
 }
 
 function isCurrentDocumentLoad(state: AppStore, requestPath: string, loadToken: number) {

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import { extractHeadings } from "@/lib/markdown";
 import {
+  deleteMarkdownFile,
   getInitialSession,
   readMarkdownFile,
   refreshSession,
@@ -44,6 +45,7 @@ interface AppStore {
   applyScanProgress: (payload: ScanProgressPayload) => Promise<void>;
   bootstrap: () => Promise<void>;
   openDocument: (relativePath: string) => Promise<void>;
+  deleteCurrentDocument: () => Promise<void>;
   setDocumentMode: (mode: DocumentMode) => void;
   updateDraftContent: (content: string) => void;
   saveCurrentDocument: () => Promise<void>;
@@ -162,6 +164,38 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
       set({
         document: createErrorDocument(error instanceof Error ? error.message : "문서를 열지 못했습니다."),
+      });
+    }
+  },
+  deleteCurrentDocument: async () => {
+    const state = get();
+    const current = state.selectedFile;
+    if (!current) {
+      return;
+    }
+    if (!window.confirm(`정말로 \"${current}\" 문서를 삭제할까요?`)) {
+      return;
+    }
+
+    set({ document: createLoadingDocument() });
+
+    try {
+      const result = await deleteMarkdownFile(current);
+      const files = state.files.filter((entry) => entry !== result.deletedRelativePath);
+      set({
+        files,
+        fileSet: new Set(files),
+        selectedFile: result.nextSelectedFile,
+        document: result.nextSelectedFile ? createLoadingDocument() : createEmptyDocument(),
+      });
+
+      if (result.nextSelectedFile) {
+        await get().openDocument(result.nextSelectedFile);
+      }
+    } catch (error) {
+      set({
+        selectedFile: current,
+        document: createErrorDocument(error instanceof Error ? error.message : "문서를 삭제하지 못했습니다."),
       });
     }
   },

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -136,9 +136,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
   openDocument: async (relativePath) => {
     const requestPath = relativePath;
     const current = get();
-    if (current.document.isDirty && !confirmDiscardUnsavedChanges()) {
-      return;
-    }
 
     const loadToken = current.documentLoadToken + 1;
     set({
@@ -169,9 +166,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
   createDocument: async (relativePath, content = "") => {
     const state = get();
-    if (state.document.isDirty && !confirmDiscardUnsavedChanges()) {
-      return;
-    }
 
     const normalizedPath = normalizeRelativeMarkdownPath(relativePath);
     if (!normalizedPath) {
@@ -207,9 +201,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const state = get();
     const current = state.selectedFile;
     if (!current) {
-      return;
-    }
-    if (state.document.isDirty && !confirmDiscardUnsavedChanges()) {
       return;
     }
 
@@ -389,10 +380,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const previousSelection = previousState.selectedFile;
     const hadDirtyDocument = previousState.document.isDirty;
 
-    if (hadDirtyDocument && !confirmDiscardUnsavedChanges()) {
-      return;
-    }
-
     try {
       const session = await refreshSession();
       const { values: files, valueSet: fileSet } = mergeSortedUnique([], new Set(), session.files);
@@ -484,10 +471,6 @@ function createErrorDocument(message: string): AppStore["document"] {
     state: "error",
     error: message,
   };
-}
-
-function confirmDiscardUnsavedChanges() {
-  return window.confirm("저장하지 않은 변경사항이 있습니다. 변경사항을 버리고 계속할까요?");
 }
 
 function normalizeRelativeMarkdownPath(relativePath: string) {

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -30,6 +30,8 @@ interface AppStore {
   selectedFile: string | null;
   documentLoadToken: number;
   isSidebarOpen: boolean;
+  successMessage: string | null;
+  successMessageId: number;
   document: {
     state: DocumentState;
     content: string;
@@ -44,6 +46,7 @@ interface AppStore {
     externalChangeDetected: boolean;
   };
   setSidebarOpen: (open: boolean) => void;
+  clearSuccessMessage: () => void;
   applyScanProgress: (payload: ScanProgressPayload) => Promise<void>;
   bootstrap: () => Promise<void>;
   openDocument: (relativePath: string) => Promise<void>;
@@ -71,8 +74,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
   selectedFile: null,
   documentLoadToken: 0,
   isSidebarOpen: false,
+  successMessage: null,
+  successMessageId: 0,
   document: createEmptyDocument(),
   setSidebarOpen: (open) => set({ isSidebarOpen: open }),
+  clearSuccessMessage: () => set({ successMessage: null }),
   applyScanProgress: async (payload) => {
     const state = get();
     const { values: files, valueSet: fileSet } = mergeSortedUnique(state.files, state.fileSet, payload.files);
@@ -152,6 +158,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
       set({
         selectedFile: document.relativePath,
+        successMessage: null,
         document: createReadyDocument(document.content, document.headings),
       });
     } catch (error) {
@@ -181,15 +188,17 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const document = await createMarkdownFile(normalizedPath, content);
       const { values: files, valueSet: fileSet } = mergeSortedUnique(state.files, state.fileSet, [document.relativePath]);
-      set({
+      set((state) => ({
         files,
         fileSet,
         selectedFile: document.relativePath,
+        successMessage: `새 문서를 만들었습니다: ${document.relativePath}`,
+        successMessageId: state.successMessageId + 1,
         document: {
           ...createReadyDocument(document.content, document.headings),
           mode: "edit",
         },
-      });
+      }));
     } catch (error) {
       set({
         selectedFile: state.selectedFile,
@@ -217,12 +226,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
         .filter((entry) => entry !== result.oldRelativePath)
         .concat(result.document.relativePath)
         .sort((a, b) => a.localeCompare(b));
-      set({
+      set((state) => ({
         files,
         fileSet: new Set(files),
         selectedFile: result.document.relativePath,
+        successMessage: `문서 이름을 변경했습니다: ${result.document.relativePath}`,
+        successMessageId: state.successMessageId + 1,
         document: createReadyDocument(result.document.content, result.document.headings),
-      });
+      }));
     } catch (error) {
       set({
         selectedFile: current,
@@ -242,12 +253,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const result = await deleteMarkdownFile(current);
       const files = state.files.filter((entry) => entry !== result.deletedRelativePath);
-      set({
+      set((state) => ({
         files,
         fileSet: new Set(files),
         selectedFile: result.nextSelectedFile,
+        successMessage: `문서를 삭제했습니다: ${result.deletedRelativePath}`,
+        successMessageId: state.successMessageId + 1,
         document: result.nextSelectedFile ? createLoadingDocument() : createEmptyDocument(),
-      });
+      }));
 
       if (result.nextSelectedFile) {
         await get().openDocument(result.nextSelectedFile);
@@ -269,6 +282,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
   updateDraftContent: (content) => {
     set((state) => ({
+      successMessage: null,
       document: {
         ...state.document,
         content,
@@ -303,14 +317,16 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     try {
       const document = await writeMarkdownFile(current, draftContent);
-      set({
+      set((state) => ({
         selectedFile: document.relativePath,
+        successMessage: `저장했습니다: ${document.relativePath}`,
+        successMessageId: state.successMessageId + 1,
         document: {
           ...createReadyDocument(document.content, document.headings),
           mode: get().document.mode,
           lastSavedAt: new Date().toISOString(),
         },
-      });
+      }));
     } catch (error) {
       set((state) => ({
         document: {
@@ -351,6 +367,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }
 
       set((state) => ({
+        successMessage: null,
         selectedFile: document.relativePath,
         document: {
           ...createReadyDocument(document.content, document.headings),
@@ -393,6 +410,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         scanSkippedPaths: [],
         scanSkippedPathSet: new Set(),
         scanError: null,
+        successMessage: null,
       });
 
       if (previousSelection && session.files.includes(previousSelection)) {

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -18,6 +18,11 @@ export interface MarkdownDocument {
   headings: HeadingItem[];
 }
 
+export interface RenameMarkdownResult {
+  oldRelativePath: string;
+  document: MarkdownDocument;
+}
+
 export interface DeleteMarkdownResult {
   deletedRelativePath: string;
   nextSelectedFile: string | null;

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -17,3 +17,8 @@ export interface MarkdownDocument {
   content: string;
   headings: HeadingItem[];
 }
+
+export interface DeleteMarkdownResult {
+  deletedRelativePath: string;
+  nextSelectedFile: string | null;
+}


### PR DESCRIPTION
## Summary
- add a save-and-continue action to the unsaved-change dialog
- continue the pending navigation/refresh/close action only after save succeeds
- keep the current document in place when save fails or the draft remains dirty

Closes #33