### PR TITLE
test: cover document safety store flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ pnpm dev
 ## 검증
 
 ```bash
+pnpm test
 pnpm typecheck
 cargo check --manifest-path src-tauri/Cargo.toml
 pnpm build

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri"
@@ -38,6 +39,7 @@
     "tailwindcss": "^4.2.2",
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.8.3",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       vite:
         specifier: ^7.0.4
         version: 7.3.2(jiti@2.6.1)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0))
 
 packages:
 
@@ -608,66 +611,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -698,6 +714,9 @@ packages:
     resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
     cpu: [x64]
     os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
@@ -737,24 +756,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -820,30 +843,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.10.1':
     resolution: {integrity: sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
     resolution: {integrity: sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.10.1':
     resolution: {integrity: sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.10.1':
     resolution: {integrity: sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
     resolution: {integrity: sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==}
@@ -882,6 +910,9 @@ packages:
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -979,6 +1010,9 @@ packages:
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -1026,6 +1060,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -1034,6 +1097,10 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -1053,6 +1120,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1311,6 +1382,9 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -1326,6 +1400,13 @@ packages:
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1476,24 +1557,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1685,6 +1770,9 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
@@ -1812,12 +1900,21 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -1841,6 +1938,9 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -1848,6 +1948,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -1973,6 +2077,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -1992,6 +2137,11 @@ packages:
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2507,6 +2657,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.2.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -2654,6 +2806,11 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
@@ -2775,6 +2932,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -2827,11 +2986,54 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(jiti@2.6.1)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn@8.16.0: {}
 
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  assertion-error@2.0.1: {}
 
   bail@2.0.2: {}
 
@@ -2848,6 +3050,8 @@ snapshots:
   caniuse-lite@1.0.30001787: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -3117,6 +3321,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.2
 
+  es-module-lexer@2.1.0: {}
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -3151,6 +3357,12 @@ snapshots:
   escape-string-regexp@5.0.0: {}
 
   estree-util-is-identifier-name@3.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -3714,6 +3926,8 @@ snapshots:
 
   node-releases@2.0.37: {}
 
+  obug@2.1.1: {}
+
   package-manager-detector@1.6.0: {}
 
   parse-entities@4.0.2:
@@ -3904,9 +4118,15 @@ snapshots:
 
   semver@6.3.1: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stringify-entities@4.0.4:
     dependencies:
@@ -3929,12 +4149,16 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   trim-lines@3.0.1: {}
 
@@ -4036,6 +4260,31 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
 
+  vitest@4.1.5(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(jiti@2.6.1)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -4052,6 +4301,11 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yallist@3.1.1: {}
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,13 @@ struct MarkdownDocument {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct RenameMarkdownResult {
+    old_relative_path: String,
+    document: MarkdownDocument,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct DeleteMarkdownResult {
     deleted_relative_path: String,
     next_selected_file: Option<String>,
@@ -237,6 +244,119 @@ fn write_markdown_file(
 }
 
 #[tauri::command]
+fn create_markdown_file(
+    relative_path: String,
+    content: Option<String>,
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, AppState>,
+) -> Result<MarkdownDocument, String> {
+    let mut sessions = state
+        .sessions
+        .lock()
+        .map_err(|_| "failed to acquire sessions lock".to_string())?;
+
+    let session = sessions
+        .get_mut(window.label())
+        .ok_or_else(|| format!("no session for window {}", window.label()))?;
+
+    let file_path = create_session_markdown_path(session, &relative_path)?;
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!("failed to create parent directory {}: {}", parent.display(), error)
+        })?;
+    }
+
+    let content = content.unwrap_or_default();
+    fs::write(&file_path, &content)
+        .map_err(|error| format!("failed to create markdown file {}: {}", file_path.display(), error))?;
+
+    if !session.files.iter().any(|entry| entry == &relative_path) {
+        session.files.push(relative_path.clone());
+        session.files.sort();
+    }
+    session.selected_file = Some(relative_path.clone());
+
+    Ok(MarkdownDocument {
+        relative_path,
+        headings: extract_headings(&content),
+        content,
+    })
+}
+
+#[tauri::command]
+fn rename_markdown_file(
+    from_relative_path: String,
+    to_relative_path: String,
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, AppState>,
+) -> Result<RenameMarkdownResult, String> {
+    let mut sessions = state
+        .sessions
+        .lock()
+        .map_err(|_| "failed to acquire sessions lock".to_string())?;
+
+    let session = sessions
+        .get_mut(window.label())
+        .ok_or_else(|| format!("no session for window {}", window.label()))?;
+
+    if !session.files.iter().any(|entry| entry == &from_relative_path) {
+        return Err(format!(
+            "document is not available in the current root: {}",
+            from_relative_path
+        ));
+    }
+
+    if from_relative_path == to_relative_path {
+        return Err("new path must be different from the current path".to_string());
+    }
+
+    let from_file_path = session.root_dir.join(&from_relative_path);
+    let canonical_from = canonical_file_inside_root(
+        &session.canonical_root_dir,
+        &from_file_path,
+        &from_relative_path,
+    )?;
+    let target_file_path = create_session_markdown_path(session, &to_relative_path)?;
+
+    if let Some(parent) = target_file_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!("failed to create parent directory {}: {}", parent.display(), error)
+        })?;
+    }
+
+    fs::rename(&canonical_from, &target_file_path).map_err(|error| {
+        format!(
+            "failed to rename markdown file {} -> {}: {}",
+            from_relative_path, to_relative_path, error
+        )
+    })?;
+
+    session.files.retain(|entry| entry != &from_relative_path);
+    session.files.push(to_relative_path.clone());
+    session.files.sort();
+    if session.selected_file.as_deref() == Some(&from_relative_path) {
+        session.selected_file = Some(to_relative_path.clone());
+    }
+
+    let content = fs::read_to_string(&target_file_path).map_err(|error| {
+        format!(
+            "failed to read renamed markdown file {}: {}",
+            target_file_path.display(),
+            error
+        )
+    })?;
+
+    Ok(RenameMarkdownResult {
+        old_relative_path: from_relative_path,
+        document: MarkdownDocument {
+            relative_path: to_relative_path,
+            headings: extract_headings(&content),
+            content,
+        },
+    })
+}
+
+#[tauri::command]
 fn delete_markdown_file(
     relative_path: String,
     window: tauri::WebviewWindow,
@@ -339,6 +459,8 @@ pub fn run() {
             refresh_session,
             read_markdown_file,
             write_markdown_file,
+            create_markdown_file,
+            rename_markdown_file,
             delete_markdown_file
         ])
         .run(tauri::generate_context!())
@@ -996,6 +1118,38 @@ fn canonical_file_inside_root(
     }
 
     Ok(canonical_file)
+}
+
+fn create_session_markdown_path(session: &SessionState, relative_path: &str) -> Result<PathBuf, String> {
+    let relative = Path::new(relative_path);
+    if relative_path.trim().is_empty()
+        || relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(format!("invalid relative markdown path: {}", relative_path));
+    }
+
+    let file_path = session.root_dir.join(relative);
+    if !is_markdown_file(&file_path) {
+        return Err(format!("document is not a markdown file: {}", relative_path));
+    }
+
+    if session.files.iter().any(|entry| entry == relative_path) || file_path.exists() {
+        return Err(format!("document already exists: {}", relative_path));
+    }
+
+    let canonical_parent = file_path
+        .parent()
+        .unwrap_or(&session.root_dir)
+        .canonicalize()
+        .unwrap_or_else(|_| session.root_dir.clone());
+    if !canonical_parent.starts_with(&session.canonical_root_dir) {
+        return Err(format!("document is outside the current root: {}", relative_path));
+    }
+
+    Ok(file_path)
 }
 
 fn path_to_relative(root_dir: &Path, path: &Path) -> Option<String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,13 @@ struct MarkdownDocument {
     headings: Vec<HeadingItem>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DeleteMarkdownResult {
+    deleted_relative_path: String,
+    next_selected_file: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 struct SessionState {
     root_dir: PathBuf,
@@ -229,6 +236,54 @@ fn write_markdown_file(
     })
 }
 
+#[tauri::command]
+fn delete_markdown_file(
+    relative_path: String,
+    window: tauri::WebviewWindow,
+    state: tauri::State<'_, AppState>,
+) -> Result<DeleteMarkdownResult, String> {
+    let mut sessions = state
+        .sessions
+        .lock()
+        .map_err(|_| "failed to acquire sessions lock".to_string())?;
+
+    let session = sessions
+        .get_mut(window.label())
+        .ok_or_else(|| format!("no session for window {}", window.label()))?;
+
+    if !session.files.iter().any(|entry| entry == &relative_path) {
+        return Err(format!(
+            "document is not available in the current root: {}",
+            relative_path
+        ));
+    }
+
+    let file_path = session.root_dir.join(&relative_path);
+    let canonical_file =
+        canonical_file_inside_root(&session.canonical_root_dir, &file_path, &relative_path)?;
+    fs::remove_file(&canonical_file).map_err(|error| {
+        format!(
+            "failed to delete markdown file {}: {}",
+            canonical_file.display(),
+            error
+        )
+    })?;
+
+    session.files.retain(|entry| entry != &relative_path);
+    let next_selected_file = if session.selected_file.as_deref() == Some(&relative_path) {
+        let next = pick_default_document(&session.files);
+        session.selected_file = next.clone();
+        next
+    } else {
+        session.selected_file.clone()
+    };
+
+    Ok(DeleteMarkdownResult {
+        deleted_relative_path: relative_path,
+        next_selected_file,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Application entry point
 // ---------------------------------------------------------------------------
@@ -283,7 +338,8 @@ pub fn run() {
             get_initial_session,
             refresh_session,
             read_markdown_file,
-            write_markdown_file
+            write_markdown_file,
+            delete_markdown_file
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,9 @@ function App() {
   const bootstrapState = useAppStore((state) => state.bootstrapState);
   const error = useAppStore((state) => state.error);
   const rootDir = useAppStore((state) => state.rootDir);
+  const successMessage = useAppStore((state) => state.successMessage);
+  const successMessageId = useAppStore((state) => state.successMessageId);
+  const clearSuccessMessage = useAppStore((state) => state.clearSuccessMessage);
   const files = useAppStore((state) => state.files);
   const scanState = useAppStore((state) => state.scanState);
   const scanSkippedPaths = useAppStore((state) => state.scanSkippedPaths);
@@ -92,6 +95,18 @@ function App() {
       setRenamePath(selectedFile ?? "");
     }
   }, [isRenameDialogOpen, selectedFile]);
+
+  useEffect(() => {
+    if (!successMessage) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      clearSuccessMessage();
+    }, 2600);
+
+    return () => window.clearTimeout(timer);
+  }, [successMessage, successMessageId, clearSuccessMessage]);
 
   const selectedSegments = selectedFile?.split("/") ?? [];
   const selectedLabel = selectedSegments[selectedSegments.length - 1] ?? "문서를 선택하세요";
@@ -327,6 +342,12 @@ function App() {
                         ) : null}
                       </div>
                     </div>
+
+                    {successMessage ? (
+                      <div className="border-b border-emerald-500/20 bg-emerald-500/10 px-5 py-3 text-sm text-emerald-700">
+                        {successMessage}
+                      </div>
+                    ) : null}
 
                     {document.externalChangeDetected ? (
                       <div className="border-b border-border/60 bg-secondary px-5 py-3 text-sm text-secondary-foreground">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -273,8 +273,23 @@ function App() {
   };
 
   const handleDeleteDocument = async () => {
-    await deleteCurrentDocument();
-    setDeleteDialogOpen(false);
+    const execute = async () => {
+      await deleteCurrentDocument();
+      setDeleteDialogOpen(false);
+    };
+
+    if (document.isDirty) {
+      setDeleteDialogOpen(false);
+      setPendingUnsavedAction({
+        title: "삭제 전에 확인해주세요",
+        description: "현재 문서의 저장되지 않은 편집 내용이 있습니다. 저장 후 삭제하거나, 변경사항을 버리고 선택한 문서를 삭제할 수 있습니다.",
+        confirmLabel: "변경사항 버리고 삭제",
+        run: execute,
+      });
+      return;
+    }
+
+    await execute();
   };
 
   const handleConfirmPendingUnsavedAction = async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect, useMemo, useState } from "react";
 import { Edit3, Eye, FilePenLine, FilePlus2, FileText, FolderTree, Menu, RefreshCcw, Save, TextSearch, Trash2 } from "lucide-react";
 
 import { FileTree } from "@/components/file-tree";
@@ -9,15 +8,9 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { useUnsavedChangeGuard } from "@/hooks/use-unsaved-change-guard";
 import { useAppStore } from "@/store/app-store";
 import { subscribeToFsChanges, subscribeToScanProgress } from "@/store/fs-watcher";
-
-type PendingUnsavedAction = {
-  title: string;
-  description: string;
-  confirmLabel: string;
-  run: () => Promise<void> | void;
-};
 
 function App() {
   const bootstrap = useAppStore((state) => state.bootstrap);
@@ -51,14 +44,15 @@ function App() {
   const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [createPath, setCreatePath] = useState("untitled.md");
   const [renamePath, setRenamePath] = useState("");
-  const [pendingUnsavedAction, setPendingUnsavedAction] = useState<PendingUnsavedAction | null>(null);
-  const allowWindowCloseRef = useRef(false);
-
-  const canSaveDocument =
-    document.state === "ready" &&
-    document.isDirty &&
-    !document.isSaving &&
-    !document.externalChangeDetected;
+  const {
+    canSaveDocument,
+    pendingUnsavedAction,
+    requestUnsavedConfirmation,
+    runGuardedAction,
+    clearPendingUnsavedAction,
+    confirmPendingUnsavedAction,
+    saveAndContinuePendingAction,
+  } = useUnsavedChangeGuard();
 
   useEffect(() => {
     void bootstrap();
@@ -110,63 +104,6 @@ function App() {
     return () => window.clearTimeout(timer);
   }, [successMessage, successMessageId, clearSuccessMessage]);
 
-  useEffect(() => {
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (!document.isDirty || allowWindowCloseRef.current) {
-        return;
-      }
-
-      event.preventDefault();
-      event.returnValue = "";
-    };
-
-    window.addEventListener("beforeunload", handleBeforeUnload);
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [document.isDirty]);
-
-  useEffect(() => {
-    let isDisposed = false;
-    let cleanup: (() => void) | undefined;
-
-    const setupCloseGuard = async () => {
-      try {
-        const appWindow = getCurrentWindow();
-        const unlisten = await appWindow.onCloseRequested(async (event) => {
-          if (allowWindowCloseRef.current || !document.isDirty) {
-            return;
-          }
-
-          event.preventDefault();
-          setPendingUnsavedAction({
-            title: "저장하지 않은 변경사항이 있습니다",
-            description: "이 창을 닫으면 현재 문서의 저장되지 않은 편집 내용이 사라집니다. 저장 후 닫거나, 변경사항을 버리고 닫을 수 있습니다.",
-            confirmLabel: "변경사항 버리고 닫기",
-            run: async () => {
-              allowWindowCloseRef.current = true;
-              await appWindow.close();
-            },
-          });
-        });
-
-        if (isDisposed) {
-          unlisten();
-          return;
-        }
-
-        cleanup = unlisten;
-      } catch {
-        // non-tauri surface
-      }
-    };
-
-    void setupCloseGuard();
-
-    return () => {
-      isDisposed = true;
-      cleanup?.();
-    };
-  }, [document.isDirty]);
-
   const selectedSegments = selectedFile?.split("/") ?? [];
   const selectedLabel = selectedSegments[selectedSegments.length - 1] ?? "문서를 선택하세요";
   const deleteDescription = useMemo(() => {
@@ -175,15 +112,6 @@ function App() {
     }
     return `"${selectedFile}" 문서를 삭제합니다. 삭제 후에는 복구되지 않습니다.`;
   }, [selectedFile]);
-
-  const runGuardedAction = (action: PendingUnsavedAction) => {
-    if (document.isDirty) {
-      setPendingUnsavedAction(action);
-      return;
-    }
-
-    void action.run();
-  };
 
   const handleOpenDocument = (file: string) => {
     if (file === selectedFile) {
@@ -235,7 +163,7 @@ function App() {
 
     if (document.isDirty) {
       setCreateDialogOpen(false);
-      setPendingUnsavedAction({
+      requestUnsavedConfirmation({
         title: "새 문서를 만들기 전에 확인해주세요",
         description: "현재 문서의 저장되지 않은 편집 내용이 있습니다. 계속하면 지금 편집본은 사라지고, 새 문서를 만들어 바로 엽니다.",
         confirmLabel: "변경사항 버리고 생성",
@@ -260,7 +188,7 @@ function App() {
 
     if (document.isDirty) {
       setRenameDialogOpen(false);
-      setPendingUnsavedAction({
+      requestUnsavedConfirmation({
         title: "이름 변경 전에 확인해주세요",
         description: "저장하지 않은 편집 내용이 있습니다. 계속하면 현재 편집본은 사라지고, 마지막으로 저장된 파일 기준으로 이름을 변경합니다.",
         confirmLabel: "변경사항 버리고 변경",
@@ -280,7 +208,7 @@ function App() {
 
     if (document.isDirty) {
       setDeleteDialogOpen(false);
-      setPendingUnsavedAction({
+      requestUnsavedConfirmation({
         title: "삭제 전에 확인해주세요",
         description: "현재 문서의 저장되지 않은 편집 내용이 있습니다. 저장 후 삭제하거나, 변경사항을 버리고 선택한 문서를 삭제할 수 있습니다.",
         confirmLabel: "변경사항 버리고 삭제",
@@ -290,33 +218,6 @@ function App() {
     }
 
     await execute();
-  };
-
-  const handleConfirmPendingUnsavedAction = async () => {
-    if (!pendingUnsavedAction) {
-      return;
-    }
-
-    const action = pendingUnsavedAction;
-    setPendingUnsavedAction(null);
-    await action.run();
-  };
-
-  const handleSaveAndContinuePendingAction = async () => {
-    if (!pendingUnsavedAction) {
-      return;
-    }
-
-    await saveCurrentDocument();
-
-    const latestDocument = useAppStore.getState().document;
-    if (latestDocument.isDirty || latestDocument.error) {
-      return;
-    }
-
-    const action = pendingUnsavedAction;
-    setPendingUnsavedAction(null);
-    await action.run();
   };
 
   return (
@@ -540,7 +441,7 @@ function App() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={pendingUnsavedAction !== null} onOpenChange={(open) => !open && setPendingUnsavedAction(null)}>
+      <Dialog open={pendingUnsavedAction !== null} onOpenChange={(open) => !open && clearPendingUnsavedAction()}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{pendingUnsavedAction?.title ?? "저장되지 않은 변경사항"}</DialogTitle>
@@ -549,13 +450,13 @@ function App() {
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setPendingUnsavedAction(null)}>
+            <Button variant="outline" onClick={clearPendingUnsavedAction}>
               취소
             </Button>
-            <Button variant="outline" disabled={!canSaveDocument} onClick={() => void handleSaveAndContinuePendingAction()}>
+            <Button variant="outline" disabled={!canSaveDocument} onClick={() => void saveAndContinuePendingAction()}>
               {document.isSaving ? "저장 중" : "저장 후 계속"}
             </Button>
-            <Button onClick={() => void handleConfirmPendingUnsavedAction()}>
+            <Button onClick={() => void confirmPendingUnsavedAction()}>
               {pendingUnsavedAction?.confirmLabel ?? "계속"}
             </Button>
           </DialogFooter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Edit3, Eye, FilePenLine, FilePlus2, FileText, FolderTree, Menu, RefreshCcw, Save, TextSearch, Trash2 } from "lucide-react";
 
 import { FileTree } from "@/components/file-tree";
@@ -51,6 +52,7 @@ function App() {
   const [createPath, setCreatePath] = useState("untitled.md");
   const [renamePath, setRenamePath] = useState("");
   const [pendingUnsavedAction, setPendingUnsavedAction] = useState<PendingUnsavedAction | null>(null);
+  const allowWindowCloseRef = useRef(false);
 
   const canSaveDocument =
     document.state === "ready" &&
@@ -107,6 +109,63 @@ function App() {
 
     return () => window.clearTimeout(timer);
   }, [successMessage, successMessageId, clearSuccessMessage]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!document.isDirty || allowWindowCloseRef.current) {
+        return;
+      }
+
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [document.isDirty]);
+
+  useEffect(() => {
+    let isDisposed = false;
+    let cleanup: (() => void) | undefined;
+
+    const setupCloseGuard = async () => {
+      try {
+        const appWindow = getCurrentWindow();
+        const unlisten = await appWindow.onCloseRequested(async (event) => {
+          if (allowWindowCloseRef.current || !document.isDirty) {
+            return;
+          }
+
+          event.preventDefault();
+          setPendingUnsavedAction({
+            title: "변경사항 버리고 앱 닫기",
+            description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 창을 닫습니다.",
+            confirmLabel: "버리고 닫기",
+            run: async () => {
+              allowWindowCloseRef.current = true;
+              await appWindow.close();
+            },
+          });
+        });
+
+        if (isDisposed) {
+          unlisten();
+          return;
+        }
+
+        cleanup = unlisten;
+      } catch {
+        // non-tauri surface
+      }
+    };
+
+    void setupCloseGuard();
+
+    return () => {
+      isDisposed = true;
+      cleanup?.();
+    };
+  }, [document.isDirty]);
 
   const selectedSegments = selectedFile?.split("/") ?? [];
   const selectedLabel = selectedSegments[selectedSegments.length - 1] ?? "문서를 선택하세요";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,9 +138,9 @@ function App() {
 
           event.preventDefault();
           setPendingUnsavedAction({
-            title: "변경사항 버리고 앱 닫기",
-            description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 창을 닫습니다.",
-            confirmLabel: "버리고 닫기",
+            title: "저장하지 않은 변경사항이 있습니다",
+            description: "이 창을 닫으면 현재 문서의 저장되지 않은 편집 내용이 사라집니다. 저장 후 닫거나, 변경사항을 버리고 닫을 수 있습니다.",
+            confirmLabel: "변경사항 버리고 닫기",
             run: async () => {
               allowWindowCloseRef.current = true;
               await appWindow.close();
@@ -191,9 +191,9 @@ function App() {
     }
 
     runGuardedAction({
-      title: "변경사항 버리고 다른 문서 열기",
-      description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 편집 중인 내용이 사라지고 선택한 문서를 엽니다.",
-      confirmLabel: "버리고 열기",
+      title: "다른 문서를 열기 전에 확인해주세요",
+      description: "지금 문서의 저장되지 않은 편집 내용이 있습니다. 계속하면 현재 편집본은 사라지고, 선택한 문서를 엽니다.",
+      confirmLabel: "변경사항 버리고 열기",
       run: async () => {
         await openDocument(file);
         setSidebarOpen(false);
@@ -203,18 +203,18 @@ function App() {
 
   const handleRefresh = () => {
     runGuardedAction({
-      title: "변경사항 버리고 새로고침",
-      description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 디스크 기준 상태로 세션을 새로고침합니다.",
-      confirmLabel: "버리고 새로고침",
+      title: "새로고침 전에 확인해주세요",
+      description: "저장하지 않은 편집 내용이 있습니다. 계속하면 현재 편집본을 버리고, 디스크 기준 상태로 목록과 문서를 다시 불러옵니다.",
+      confirmLabel: "변경사항 버리고 새로고침",
       run: refresh,
     });
   };
 
   const handleReloadFromDisk = () => {
     runGuardedAction({
-      title: "변경사항 버리고 다시 불러오기",
-      description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 파일을 디스크 상태로 다시 불러옵니다.",
-      confirmLabel: "디스크에서 다시 불러오기",
+      title: "디스크의 파일로 되돌릴까요?",
+      description: "저장하지 않은 편집 내용이 있습니다. 계속하면 현재 편집본을 버리고, 파일을 디스크에 저장된 상태로 다시 불러옵니다.",
+      confirmLabel: "변경사항 버리고 다시 불러오기",
       run: async () => {
         await reloadCurrentDocument(true);
       },
@@ -236,9 +236,9 @@ function App() {
     if (document.isDirty) {
       setCreateDialogOpen(false);
       setPendingUnsavedAction({
-        title: "변경사항 버리고 새 문서 생성",
-        description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 새 문서를 생성해 엽니다.",
-        confirmLabel: "버리고 생성",
+        title: "새 문서를 만들기 전에 확인해주세요",
+        description: "현재 문서의 저장되지 않은 편집 내용이 있습니다. 계속하면 지금 편집본은 사라지고, 새 문서를 만들어 바로 엽니다.",
+        confirmLabel: "변경사항 버리고 생성",
         run: execute,
       });
       return;
@@ -261,9 +261,9 @@ function App() {
     if (document.isDirty) {
       setRenameDialogOpen(false);
       setPendingUnsavedAction({
-        title: "변경사항 버리고 문서 이름 변경",
-        description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 저장된 파일 기준으로 이름을 변경합니다.",
-        confirmLabel: "버리고 변경",
+        title: "이름 변경 전에 확인해주세요",
+        description: "저장하지 않은 편집 내용이 있습니다. 계속하면 현재 편집본은 사라지고, 마지막으로 저장된 파일 기준으로 이름을 변경합니다.",
+        confirmLabel: "변경사항 버리고 변경",
         run: execute,
       });
       return;
@@ -530,7 +530,7 @@ function App() {
           <DialogHeader>
             <DialogTitle>{pendingUnsavedAction?.title ?? "저장되지 않은 변경사항"}</DialogTitle>
             <DialogDescription>
-              {pendingUnsavedAction?.description ?? "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft가 사라집니다."}
+              {pendingUnsavedAction?.description ?? "저장하지 않은 편집 내용이 있습니다. 저장 후 계속하거나, 변경사항을 버리고 진행할 수 있습니다."}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,13 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/co
 import { useAppStore } from "@/store/app-store";
 import { subscribeToFsChanges, subscribeToScanProgress } from "@/store/fs-watcher";
 
+type PendingUnsavedAction = {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  run: () => Promise<void> | void;
+};
+
 function App() {
   const bootstrap = useAppStore((state) => state.bootstrap);
   const openDocument = useAppStore((state) => state.openDocument);
@@ -40,6 +47,7 @@ function App() {
   const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [createPath, setCreatePath] = useState("untitled.md");
   const [renamePath, setRenamePath] = useState("");
+  const [pendingUnsavedAction, setPendingUnsavedAction] = useState<PendingUnsavedAction | null>(null);
 
   const canSaveDocument =
     document.state === "ready" &&
@@ -94,30 +102,115 @@ function App() {
     return `"${selectedFile}" 문서를 삭제합니다. 삭제 후에는 복구되지 않습니다.`;
   }, [selectedFile]);
 
-  const handleCreateDocument = async () => {
+  const runGuardedAction = (action: PendingUnsavedAction) => {
+    if (document.isDirty) {
+      setPendingUnsavedAction(action);
+      return;
+    }
+
+    void action.run();
+  };
+
+  const handleOpenDocument = (file: string) => {
+    if (file === selectedFile) {
+      return;
+    }
+
+    runGuardedAction({
+      title: "변경사항 버리고 다른 문서 열기",
+      description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 편집 중인 내용이 사라지고 선택한 문서를 엽니다.",
+      confirmLabel: "버리고 열기",
+      run: async () => {
+        await openDocument(file);
+        setSidebarOpen(false);
+      },
+    });
+  };
+
+  const handleRefresh = () => {
+    runGuardedAction({
+      title: "변경사항 버리고 새로고침",
+      description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 디스크 기준 상태로 세션을 새로고침합니다.",
+      confirmLabel: "버리고 새로고침",
+      run: refresh,
+    });
+  };
+
+  const handleReloadFromDisk = () => {
+    runGuardedAction({
+      title: "변경사항 버리고 다시 불러오기",
+      description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 파일을 디스크 상태로 다시 불러옵니다.",
+      confirmLabel: "디스크에서 다시 불러오기",
+      run: async () => {
+        await reloadCurrentDocument(true);
+      },
+    });
+  };
+
+  const handleCreateDocument = () => {
     const nextPath = createPath.trim();
     if (!nextPath) {
       return;
     }
 
-    await createDocument(nextPath, "");
-    setCreateDialogOpen(false);
-    setCreatePath("untitled.md");
+    const execute = async () => {
+      await createDocument(nextPath, "");
+      setCreateDialogOpen(false);
+      setCreatePath("untitled.md");
+    };
+
+    if (document.isDirty) {
+      setCreateDialogOpen(false);
+      setPendingUnsavedAction({
+        title: "변경사항 버리고 새 문서 생성",
+        description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 새 문서를 생성해 엽니다.",
+        confirmLabel: "버리고 생성",
+        run: execute,
+      });
+      return;
+    }
+
+    void execute();
   };
 
-  const handleRenameDocument = async () => {
+  const handleRenameDocument = () => {
     const nextPath = renamePath.trim();
     if (!nextPath || !selectedFile) {
       return;
     }
 
-    await renameCurrentDocument(nextPath);
-    setRenameDialogOpen(false);
+    const execute = async () => {
+      await renameCurrentDocument(nextPath);
+      setRenameDialogOpen(false);
+    };
+
+    if (document.isDirty) {
+      setRenameDialogOpen(false);
+      setPendingUnsavedAction({
+        title: "변경사항 버리고 문서 이름 변경",
+        description: "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft를 버리고 저장된 파일 기준으로 이름을 변경합니다.",
+        confirmLabel: "버리고 변경",
+        run: execute,
+      });
+      return;
+    }
+
+    void execute();
   };
 
   const handleDeleteDocument = async () => {
     await deleteCurrentDocument();
     setDeleteDialogOpen(false);
+  };
+
+  const handleConfirmPendingUnsavedAction = async () => {
+    if (!pendingUnsavedAction) {
+      return;
+    }
+
+    const action = pendingUnsavedAction;
+    setPendingUnsavedAction(null);
+    await action.run();
   };
 
   return (
@@ -156,10 +249,7 @@ function App() {
                         scanState={scanState}
                         skippedCount={scanSkippedPaths.length}
                         selectedFile={selectedFile}
-                        onSelect={(file) => {
-                          void openDocument(file);
-                          setSidebarOpen(false);
-                        }}
+                        onSelect={handleOpenDocument}
                       />
                     </div>
                   </SheetContent>
@@ -180,7 +270,7 @@ function App() {
                   삭제
                 </Button>
 
-                <Button variant="outline" size="sm" onClick={() => void refresh()}>
+                <Button variant="outline" size="sm" onClick={handleRefresh}>
                   <RefreshCcw className="mr-2 h-4 w-4" />
                   새로고침
                 </Button>
@@ -201,7 +291,7 @@ function App() {
                     scanState={scanState}
                     skippedCount={scanSkippedPaths.length}
                     selectedFile={selectedFile}
-                    onSelect={(file) => void openDocument(file)}
+                    onSelect={handleOpenDocument}
                   />
                 </div>
               </aside>
@@ -243,7 +333,7 @@ function App() {
                         <div className="flex flex-wrap items-center justify-between gap-3">
                           <span>파일이 디스크에서 변경되었습니다.</span>
                           <div className="flex items-center gap-2">
-                            <Button variant="outline" size="sm" onClick={() => void reloadCurrentDocument(true)}>
+                            <Button variant="outline" size="sm" onClick={handleReloadFromDisk}>
                               디스크에서 다시 불러오기
                             </Button>
                             <Button variant="ghost" size="sm" onClick={keepDraftAfterExternalChange}>
@@ -273,7 +363,7 @@ function App() {
                         content={document.content}
                         currentRelativePath={selectedFile}
                         knownDocuments={files}
-                        onNavigate={openDocument}
+                        onNavigate={(path) => handleOpenDocument(path)}
                       />
                     ) : (
                       <EmptyReader />
@@ -306,7 +396,7 @@ function App() {
         onValueChange={setCreatePath}
         placeholder="untitled.md"
         confirmLabel="생성"
-        onConfirm={() => void handleCreateDocument()}
+        onConfirm={handleCreateDocument}
       />
 
       <FileActionDialog
@@ -318,7 +408,7 @@ function App() {
         onValueChange={setRenamePath}
         placeholder="docs/renamed.md"
         confirmLabel="변경"
-        onConfirm={() => void handleRenameDocument()}
+        onConfirm={handleRenameDocument}
       />
 
       <Dialog open={isDeleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
@@ -333,6 +423,25 @@ function App() {
             </Button>
             <Button disabled={!selectedFile} onClick={() => void handleDeleteDocument()}>
               삭제
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={pendingUnsavedAction !== null} onOpenChange={(open) => !open && setPendingUnsavedAction(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{pendingUnsavedAction?.title ?? "저장되지 않은 변경사항"}</DialogTitle>
+            <DialogDescription>
+              {pendingUnsavedAction?.description ?? "저장하지 않은 변경사항이 있습니다. 계속하면 현재 draft가 사라집니다."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingUnsavedAction(null)}>
+              취소
+            </Button>
+            <Button onClick={() => void handleConfirmPendingUnsavedAction()}>
+              {pendingUnsavedAction?.confirmLabel ?? "계속"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -287,6 +287,23 @@ function App() {
     await action.run();
   };
 
+  const handleSaveAndContinuePendingAction = async () => {
+    if (!pendingUnsavedAction) {
+      return;
+    }
+
+    await saveCurrentDocument();
+
+    const latestDocument = useAppStore.getState().document;
+    if (latestDocument.isDirty || latestDocument.error) {
+      return;
+    }
+
+    const action = pendingUnsavedAction;
+    setPendingUnsavedAction(null);
+    await action.run();
+  };
+
   return (
     <>
       <div className="min-h-screen bg-background text-foreground">
@@ -519,6 +536,9 @@ function App() {
           <DialogFooter>
             <Button variant="outline" onClick={() => setPendingUnsavedAction(null)}>
               취소
+            </Button>
+            <Button variant="outline" disabled={!canSaveDocument} onClick={() => void handleSaveAndContinuePendingAction()}>
+              {document.isSaving ? "저장 중" : "저장 후 계속"}
             </Button>
             <Button onClick={() => void handleConfirmPendingUnsavedAction()}>
               {pendingUnsavedAction?.confirmLabel ?? "계속"}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Edit3, Eye, FileText, FolderTree, Menu, RefreshCcw, Save, TextSearch } from "lucide-react";
+import { Edit3, Eye, FileText, FolderTree, Menu, RefreshCcw, Save, TextSearch, Trash2 } from "lucide-react";
 
 import { FileTree } from "@/components/file-tree";
 import { MarkdownView } from "@/components/markdown-view";
@@ -13,6 +13,7 @@ import { subscribeToFsChanges, subscribeToScanProgress } from "@/store/fs-watche
 function App() {
   const bootstrap = useAppStore((state) => state.bootstrap);
   const openDocument = useAppStore((state) => state.openDocument);
+  const deleteCurrentDocument = useAppStore((state) => state.deleteCurrentDocument);
   const refresh = useAppStore((state) => state.refresh);
   const setDocumentMode = useAppStore((state) => state.setDocumentMode);
   const updateDraftContent = useAppStore((state) => state.updateDraftContent);
@@ -114,6 +115,11 @@ function App() {
                   </div>
                 </SheetContent>
               </Sheet>
+
+              <Button variant="outline" size="sm" disabled={!selectedFile} onClick={() => void deleteCurrentDocument()}>
+                <Trash2 className="mr-2 h-4 w-4" />
+                삭제
+              </Button>
 
               <Button variant="outline" size="sm" onClick={() => void refresh()}>
                 <RefreshCcw className="mr-2 h-4 w-4" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
-import { useEffect } from "react";
-import { Edit3, Eye, FileText, FolderTree, Menu, RefreshCcw, Save, TextSearch, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Edit3, Eye, FilePenLine, FilePlus2, FileText, FolderTree, Menu, RefreshCcw, Save, TextSearch, Trash2 } from "lucide-react";
 
 import { FileTree } from "@/components/file-tree";
 import { MarkdownView } from "@/components/markdown-view";
 import { TableOfContents } from "@/components/table-of-contents";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { useAppStore } from "@/store/app-store";
 import { subscribeToFsChanges, subscribeToScanProgress } from "@/store/fs-watcher";
@@ -13,6 +14,8 @@ import { subscribeToFsChanges, subscribeToScanProgress } from "@/store/fs-watche
 function App() {
   const bootstrap = useAppStore((state) => state.bootstrap);
   const openDocument = useAppStore((state) => state.openDocument);
+  const createDocument = useAppStore((state) => state.createDocument);
+  const renameCurrentDocument = useAppStore((state) => state.renameCurrentDocument);
   const deleteCurrentDocument = useAppStore((state) => state.deleteCurrentDocument);
   const refresh = useAppStore((state) => state.refresh);
   const setDocumentMode = useAppStore((state) => state.setDocumentMode);
@@ -31,6 +34,13 @@ function App() {
   const document = useAppStore((state) => state.document);
   const isSidebarOpen = useAppStore((state) => state.isSidebarOpen);
   const setSidebarOpen = useAppStore((state) => state.setSidebarOpen);
+
+  const [isCreateDialogOpen, setCreateDialogOpen] = useState(false);
+  const [isRenameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [createPath, setCreatePath] = useState("untitled.md");
+  const [renamePath, setRenamePath] = useState("");
+
   const canSaveDocument =
     document.state === "ready" &&
     document.isDirty &&
@@ -69,180 +79,325 @@ function App() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [canSaveDocument, saveCurrentDocument]);
 
+  useEffect(() => {
+    if (isRenameDialogOpen) {
+      setRenamePath(selectedFile ?? "");
+    }
+  }, [isRenameDialogOpen, selectedFile]);
+
   const selectedSegments = selectedFile?.split("/") ?? [];
   const selectedLabel = selectedSegments[selectedSegments.length - 1] ?? "문서를 선택하세요";
+  const deleteDescription = useMemo(() => {
+    if (!selectedFile) {
+      return "선택된 문서가 없습니다.";
+    }
+    return `"${selectedFile}" 문서를 삭제합니다. 삭제 후에는 복구되지 않습니다.`;
+  }, [selectedFile]);
+
+  const handleCreateDocument = async () => {
+    const nextPath = createPath.trim();
+    if (!nextPath) {
+      return;
+    }
+
+    await createDocument(nextPath, "");
+    setCreateDialogOpen(false);
+    setCreatePath("untitled.md");
+  };
+
+  const handleRenameDocument = async () => {
+    const nextPath = renamePath.trim();
+    if (!nextPath || !selectedFile) {
+      return;
+    }
+
+    await renameCurrentDocument(nextPath);
+    setRenameDialogOpen(false);
+  };
+
+  const handleDeleteDocument = async () => {
+    await deleteCurrentDocument();
+    setDeleteDialogOpen(false);
+  };
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <main className="relative mx-auto flex min-h-screen max-w-[1600px] flex-col px-4 py-4 sm:px-6">
-        <header className="mb-4 rounded-lg border border-border bg-card px-4 py-3 text-card-foreground shadow-sm">
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex min-w-0 items-center gap-3">
-              <div className="flex h-11 w-11 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-sm">
-                <FileText className="h-5 w-5" />
-              </div>
-              <div className="min-w-0">
-                <p className="font-display text-xl font-semibold text-primary">MARKMINI</p>
-                <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
-                  <span className="truncate">{rootDir ?? "루트 경로를 불러오는 중"}</span>
+    <>
+      <div className="min-h-screen bg-background text-foreground">
+        <main className="relative mx-auto flex min-h-screen max-w-[1600px] flex-col px-4 py-4 sm:px-6">
+          <header className="mb-4 rounded-lg border border-border bg-card px-4 py-3 text-card-foreground shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-3">
+                <div className="flex h-11 w-11 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-sm">
+                  <FileText className="h-5 w-5" />
+                </div>
+                <div className="min-w-0">
+                  <p className="font-display text-xl font-semibold text-primary">MARKMINI</p>
+                  <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
+                    <span className="truncate">{rootDir ?? "루트 경로를 불러오는 중"}</span>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <div className="flex items-center gap-2">
-              <Sheet open={isSidebarOpen} onOpenChange={setSidebarOpen}>
-                <SheetTrigger asChild>
-                  <Button variant="outline" size="icon" className="lg:hidden">
-                    <Menu className="h-4 w-4" />
-                    <span className="sr-only">문서 목록 열기</span>
-                  </Button>
-                </SheetTrigger>
-                <SheetContent side="left" className="w-[min(88vw,340px)] p-0">
-                  <SheetHeader className="border-b border-border/60 px-5 py-4">
-                    <SheetTitle>Documents</SheetTitle>
-                  </SheetHeader>
-                  <div className="h-[calc(100vh-72px)] overflow-hidden">
-                    <FileTree
-                      files={files}
-                      scanState={scanState}
-                      skippedCount={scanSkippedPaths.length}
-                      selectedFile={selectedFile}
-                      onSelect={(file) => {
-                        void openDocument(file);
-                        setSidebarOpen(false);
-                      }}
-                    />
-                  </div>
-                </SheetContent>
-              </Sheet>
+              <div className="flex items-center gap-2">
+                <Sheet open={isSidebarOpen} onOpenChange={setSidebarOpen}>
+                  <SheetTrigger asChild>
+                    <Button variant="outline" size="icon" className="lg:hidden">
+                      <Menu className="h-4 w-4" />
+                      <span className="sr-only">문서 목록 열기</span>
+                    </Button>
+                  </SheetTrigger>
+                  <SheetContent side="left" className="w-[min(88vw,340px)] p-0">
+                    <SheetHeader className="border-b border-border/60 px-5 py-4">
+                      <SheetTitle>Documents</SheetTitle>
+                    </SheetHeader>
+                    <div className="h-[calc(100vh-72px)] overflow-hidden">
+                      <FileTree
+                        files={files}
+                        scanState={scanState}
+                        skippedCount={scanSkippedPaths.length}
+                        selectedFile={selectedFile}
+                        onSelect={(file) => {
+                          void openDocument(file);
+                          setSidebarOpen(false);
+                        }}
+                      />
+                    </div>
+                  </SheetContent>
+                </Sheet>
 
-              <Button variant="outline" size="sm" disabled={!selectedFile} onClick={() => void deleteCurrentDocument()}>
-                <Trash2 className="mr-2 h-4 w-4" />
-                삭제
-              </Button>
+                <Button variant="outline" size="sm" onClick={() => setCreateDialogOpen(true)}>
+                  <FilePlus2 className="mr-2 h-4 w-4" />
+                  새 문서
+                </Button>
 
-              <Button variant="outline" size="sm" onClick={() => void refresh()}>
-                <RefreshCcw className="mr-2 h-4 w-4" />
-                새로고침
-              </Button>
-            </div>
-          </div>
-        </header>
+                <Button variant="outline" size="sm" disabled={!selectedFile} onClick={() => setRenameDialogOpen(true)}>
+                  <FilePenLine className="mr-2 h-4 w-4" />
+                  이름 변경
+                </Button>
 
-        {bootstrapState === "loading" ? (
-          <LoadingState />
-        ) : error ? (
-          <ErrorState message={error} onRetry={() => void bootstrap()} />
-        ) : (
-          <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[300px_minmax(0,1fr)]">
-            <aside className="hidden min-h-0 lg:block">
-              <div className="sticky top-4 h-[calc(100vh-8rem)]">
-                <FileTree
-                  files={files}
-                  scanState={scanState}
-                  skippedCount={scanSkippedPaths.length}
-                  selectedFile={selectedFile}
-                  onSelect={(file) => void openDocument(file)}
-                />
+                <Button variant="outline" size="sm" disabled={!selectedFile} onClick={() => setDeleteDialogOpen(true)}>
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  삭제
+                </Button>
+
+                <Button variant="outline" size="sm" onClick={() => void refresh()}>
+                  <RefreshCcw className="mr-2 h-4 w-4" />
+                  새로고침
+                </Button>
               </div>
-            </aside>
+            </div>
+          </header>
 
-            <section className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
-              <Card className="min-h-[70vh] overflow-hidden">
-                <CardContent className="flex h-full flex-col p-0">
-                  <div className="border-b border-border/60 px-5 py-4">
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2 text-sm font-medium uppercase tracking-widest text-muted-foreground">
-                          <TextSearch className="h-4 w-4" />
-                          {document.mode === "edit" ? "Editor" : "Reader"}
-                          {document.isDirty ? <span className="tracking-normal text-destructive">저장 안 됨</span> : null}
-                        </div>
-                        <h1 className="mt-2 truncate font-display text-2xl font-semibold text-foreground">{selectedLabel}</h1>
-                      </div>
-                      {document.state === "ready" ? (
-                        <div className="flex shrink-0 items-center gap-2">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setDocumentMode(document.mode === "edit" ? "preview" : "edit")}
-                          >
-                            {document.mode === "edit" ? <Eye className="h-4 w-4" /> : <Edit3 className="h-4 w-4" />}
-                            {document.mode === "edit" ? "미리보기" : "편집"}
-                          </Button>
-                          <Button
-                            size="sm"
-                            disabled={!canSaveDocument}
-                            onClick={() => void saveCurrentDocument()}
-                          >
-                            <Save className="h-4 w-4" />
-                            {document.isSaving ? "저장 중" : "저장"}
-                          </Button>
-                        </div>
-                      ) : null}
-                    </div>
-                  </div>
-
-                  {document.externalChangeDetected ? (
-                    <div className="border-b border-border/60 bg-secondary px-5 py-3 text-sm text-secondary-foreground">
-                      <div className="flex flex-wrap items-center justify-between gap-3">
-                        <span>파일이 디스크에서 변경되었습니다.</span>
-                        <div className="flex items-center gap-2">
-                          <Button variant="outline" size="sm" onClick={() => void reloadCurrentDocument(true)}>
-                            디스크에서 다시 불러오기
-                          </Button>
-                          <Button variant="ghost" size="sm" onClick={keepDraftAfterExternalChange}>
-                            현재 편집 유지
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  ) : null}
-
-                  {document.state === "ready" && document.error ? (
-                    <div className="border-b border-destructive/30 bg-destructive/10 px-5 py-3 text-sm text-destructive">
-                      {document.error}
-                    </div>
-                  ) : null}
-
-                  {document.state === "loading" ? (
-                    <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-                      문서를 불러오는 중입니다.
-                    </div>
-                  ) : document.state === "error" ? (
-                    <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-destructive">
-                      {document.error}
-                    </div>
-                  ) : document.state === "ready" && document.mode === "edit" ? (
-                    <MarkdownEditor content={document.draftContent} onChange={updateDraftContent} />
-                  ) : document.state === "ready" ? (
-                    <MarkdownView
-                      content={document.content}
-                      currentRelativePath={selectedFile}
-                      knownDocuments={files}
-                      onNavigate={openDocument}
-                    />
-                  ) : (
-                    <EmptyReader />
-                  )}
-                </CardContent>
-              </Card>
-
-              <aside className="min-h-0">
-                <div className="sticky top-4">
-                  {scanError ? (
-                    <div className="mb-4 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                      {scanError}
-                    </div>
-                  ) : null}
-                  <TableOfContents headings={document.headings} />
+          {bootstrapState === "loading" ? (
+            <LoadingState />
+          ) : error ? (
+            <ErrorState message={error} onRetry={() => void bootstrap()} />
+          ) : (
+            <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[300px_minmax(0,1fr)]">
+              <aside className="hidden min-h-0 lg:block">
+                <div className="sticky top-4 h-[calc(100vh-8rem)]">
+                  <FileTree
+                    files={files}
+                    scanState={scanState}
+                    skippedCount={scanSkippedPaths.length}
+                    selectedFile={selectedFile}
+                    onSelect={(file) => void openDocument(file)}
+                  />
                 </div>
               </aside>
-            </section>
-          </div>
-        )}
-      </main>
-    </div>
+
+              <section className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
+                <Card className="min-h-[70vh] overflow-hidden">
+                  <CardContent className="flex h-full flex-col p-0">
+                    <div className="border-b border-border/60 px-5 py-4">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2 text-sm font-medium uppercase tracking-widest text-muted-foreground">
+                            <TextSearch className="h-4 w-4" />
+                            {document.mode === "edit" ? "Editor" : "Reader"}
+                            {document.isDirty ? <span className="tracking-normal text-destructive">저장 안 됨</span> : null}
+                          </div>
+                          <h1 className="mt-2 truncate font-display text-2xl font-semibold text-foreground">{selectedLabel}</h1>
+                        </div>
+                        {document.state === "ready" ? (
+                          <div className="flex shrink-0 items-center gap-2">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setDocumentMode(document.mode === "edit" ? "preview" : "edit")}
+                            >
+                              {document.mode === "edit" ? <Eye className="h-4 w-4" /> : <Edit3 className="h-4 w-4" />}
+                              {document.mode === "edit" ? "미리보기" : "편집"}
+                            </Button>
+                            <Button size="sm" disabled={!canSaveDocument} onClick={() => void saveCurrentDocument()}>
+                              <Save className="h-4 w-4" />
+                              {document.isSaving ? "저장 중" : "저장"}
+                            </Button>
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+
+                    {document.externalChangeDetected ? (
+                      <div className="border-b border-border/60 bg-secondary px-5 py-3 text-sm text-secondary-foreground">
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <span>파일이 디스크에서 변경되었습니다.</span>
+                          <div className="flex items-center gap-2">
+                            <Button variant="outline" size="sm" onClick={() => void reloadCurrentDocument(true)}>
+                              디스크에서 다시 불러오기
+                            </Button>
+                            <Button variant="ghost" size="sm" onClick={keepDraftAfterExternalChange}>
+                              현재 편집 유지
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    ) : null}
+
+                    {document.state === "ready" && document.error ? (
+                      <div className="border-b border-destructive/30 bg-destructive/10 px-5 py-3 text-sm text-destructive">
+                        {document.error}
+                      </div>
+                    ) : null}
+
+                    {document.state === "loading" ? (
+                      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">문서를 불러오는 중입니다.</div>
+                    ) : document.state === "error" ? (
+                      <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-destructive">
+                        {document.error}
+                      </div>
+                    ) : document.state === "ready" && document.mode === "edit" ? (
+                      <MarkdownEditor content={document.draftContent} onChange={updateDraftContent} />
+                    ) : document.state === "ready" ? (
+                      <MarkdownView
+                        content={document.content}
+                        currentRelativePath={selectedFile}
+                        knownDocuments={files}
+                        onNavigate={openDocument}
+                      />
+                    ) : (
+                      <EmptyReader />
+                    )}
+                  </CardContent>
+                </Card>
+
+                <aside className="min-h-0">
+                  <div className="sticky top-4">
+                    {scanError ? (
+                      <div className="mb-4 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                        {scanError}
+                      </div>
+                    ) : null}
+                    <TableOfContents headings={document.headings} />
+                  </div>
+                </aside>
+              </section>
+            </div>
+          )}
+        </main>
+      </div>
+
+      <FileActionDialog
+        open={isCreateDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+        title="새 markdown 문서"
+        description="루트 기준 상대 경로를 입력하면 새 markdown 문서를 생성합니다. 예: notes/today.md"
+        value={createPath}
+        onValueChange={setCreatePath}
+        placeholder="untitled.md"
+        confirmLabel="생성"
+        onConfirm={() => void handleCreateDocument()}
+      />
+
+      <FileActionDialog
+        open={isRenameDialogOpen}
+        onOpenChange={setRenameDialogOpen}
+        title="문서 이름 변경"
+        description="현재 문서를 새 상대 경로로 이동합니다. 폴더가 없으면 함께 생성됩니다."
+        value={renamePath}
+        onValueChange={setRenamePath}
+        placeholder="docs/renamed.md"
+        confirmLabel="변경"
+        onConfirm={() => void handleRenameDocument()}
+      />
+
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>문서 삭제</DialogTitle>
+            <DialogDescription>{deleteDescription}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)}>
+              취소
+            </Button>
+            <Button disabled={!selectedFile} onClick={() => void handleDeleteDocument()}>
+              삭제
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function FileActionDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  value,
+  onValueChange,
+  placeholder,
+  confirmLabel,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  placeholder: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-2">
+          <label htmlFor={title} className="text-sm font-medium text-foreground">
+            상대 경로
+          </label>
+          <input
+            id={title}
+            value={value}
+            onChange={(event) => onValueChange(event.target.value)}
+            placeholder={placeholder}
+            autoFocus
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                onConfirm();
+              }
+            }}
+            className="h-10 rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          <Button disabled={!value.trim()} onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,83 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/50 backdrop-blur-sm", className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 grid w-[min(92vw,480px)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-border bg-card p-6 text-card-foreground shadow-xl",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+        <X className="h-4 w-4" />
+        <span className="sr-only">닫기</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col space-y-2 text-left", className)} {...props} />;
+}
+
+function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)} {...props} />;
+}
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/hooks/use-unsaved-change-guard.ts
+++ b/src/hooks/use-unsaved-change-guard.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+import { useAppStore } from "@/store/app-store";
+
+export type PendingUnsavedAction = {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  run: () => Promise<void> | void;
+};
+
+export function useUnsavedChangeGuard() {
+  const document = useAppStore((state) => state.document);
+  const saveCurrentDocument = useAppStore((state) => state.saveCurrentDocument);
+  const [pendingUnsavedAction, setPendingUnsavedAction] = useState<PendingUnsavedAction | null>(null);
+  const allowWindowCloseRef = useRef(false);
+
+  const canSaveDocument =
+    document.state === "ready" &&
+    document.isDirty &&
+    !document.isSaving &&
+    !document.externalChangeDetected;
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!document.isDirty || allowWindowCloseRef.current) {
+        return;
+      }
+
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [document.isDirty]);
+
+  useEffect(() => {
+    let isDisposed = false;
+    let cleanup: (() => void) | undefined;
+
+    const setupCloseGuard = async () => {
+      try {
+        const appWindow = getCurrentWindow();
+        const unlisten = await appWindow.onCloseRequested(async (event) => {
+          if (allowWindowCloseRef.current || !document.isDirty) {
+            return;
+          }
+
+          event.preventDefault();
+          setPendingUnsavedAction({
+            title: "저장하지 않은 변경사항이 있습니다",
+            description: "이 창을 닫으면 현재 문서의 저장되지 않은 편집 내용이 사라집니다. 저장 후 닫거나, 변경사항을 버리고 닫을 수 있습니다.",
+            confirmLabel: "변경사항 버리고 닫기",
+            run: async () => {
+              allowWindowCloseRef.current = true;
+              await appWindow.close();
+            },
+          });
+        });
+
+        if (isDisposed) {
+          unlisten();
+          return;
+        }
+
+        cleanup = unlisten;
+      } catch {
+        // non-tauri surface
+      }
+    };
+
+    void setupCloseGuard();
+
+    return () => {
+      isDisposed = true;
+      cleanup?.();
+    };
+  }, [document.isDirty]);
+
+  const runGuardedAction = useCallback(
+    (action: PendingUnsavedAction) => {
+      if (document.isDirty) {
+        setPendingUnsavedAction(action);
+        return;
+      }
+
+      void action.run();
+    },
+    [document.isDirty],
+  );
+
+  const requestUnsavedConfirmation = useCallback((action: PendingUnsavedAction) => {
+    setPendingUnsavedAction(action);
+  }, []);
+
+  const clearPendingUnsavedAction = useCallback(() => {
+    setPendingUnsavedAction(null);
+  }, []);
+
+  const confirmPendingUnsavedAction = useCallback(async () => {
+    if (!pendingUnsavedAction) {
+      return;
+    }
+
+    const action = pendingUnsavedAction;
+    setPendingUnsavedAction(null);
+    await action.run();
+  }, [pendingUnsavedAction]);
+
+  const saveAndContinuePendingAction = useCallback(async () => {
+    if (!pendingUnsavedAction) {
+      return;
+    }
+
+    await saveCurrentDocument();
+
+    const latestDocument = useAppStore.getState().document;
+    if (latestDocument.isDirty || latestDocument.error) {
+      return;
+    }
+
+    const action = pendingUnsavedAction;
+    setPendingUnsavedAction(null);
+    await action.run();
+  }, [pendingUnsavedAction, saveCurrentDocument]);
+
+  return {
+    canSaveDocument,
+    pendingUnsavedAction,
+    requestUnsavedConfirmation,
+    runGuardedAction,
+    clearPendingUnsavedAction,
+    confirmPendingUnsavedAction,
+    saveAndContinuePendingAction,
+  };
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
-import type { DeleteMarkdownResult, InitialSession, MarkdownDocument, ScanStatus } from "@/types/content";
+import type { DeleteMarkdownResult, InitialSession, MarkdownDocument, RenameMarkdownResult, ScanStatus } from "@/types/content";
 
 export interface FsChangePayload {
   changedPaths: string[];
@@ -33,6 +33,14 @@ export function readMarkdownFile(relativePath: string) {
 
 export function writeMarkdownFile(relativePath: string, content: string) {
   return invoke<MarkdownDocument>("write_markdown_file", { relativePath, content });
+}
+
+export function createMarkdownFile(relativePath: string, content = "") {
+  return invoke<MarkdownDocument>("create_markdown_file", { relativePath, content });
+}
+
+export function renameMarkdownFile(fromRelativePath: string, toRelativePath: string) {
+  return invoke<RenameMarkdownResult>("rename_markdown_file", { fromRelativePath, toRelativePath });
 }
 
 export function deleteMarkdownFile(relativePath: string) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
-import type { InitialSession, MarkdownDocument, ScanStatus } from "@/types/content";
+import type { DeleteMarkdownResult, InitialSession, MarkdownDocument, ScanStatus } from "@/types/content";
 
 export interface FsChangePayload {
   changedPaths: string[];
@@ -33,6 +33,10 @@ export function readMarkdownFile(relativePath: string) {
 
 export function writeMarkdownFile(relativePath: string, content: string) {
   return invoke<MarkdownDocument>("write_markdown_file", { relativePath, content });
+}
+
+export function deleteMarkdownFile(relativePath: string) {
+  return invoke<DeleteMarkdownResult>("delete_markdown_file", { relativePath });
 }
 
 export function listenToFsChanges(handler: (payload: FsChangePayload) => void): Promise<UnlistenFn> {

--- a/src/store/app-store.test.ts
+++ b/src/store/app-store.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAppStore } from "@/store/app-store";
+import { readMarkdownFile, writeMarkdownFile } from "@/lib/tauri";
+import type { HeadingItem, MarkdownDocument } from "@/types/content";
+
+vi.mock("@/lib/tauri", () => ({
+  createMarkdownFile: vi.fn(),
+  deleteMarkdownFile: vi.fn(),
+  getInitialSession: vi.fn(),
+  readMarkdownFile: vi.fn(),
+  refreshSession: vi.fn(),
+  renameMarkdownFile: vi.fn(),
+  writeMarkdownFile: vi.fn(),
+}));
+
+const heading: HeadingItem = { depth: 1, text: "Saved", id: "saved" };
+
+function markdownDocument(relativePath: string, content: string): MarkdownDocument {
+  return {
+    relativePath,
+    content,
+    headings: [heading],
+  };
+}
+
+function resetStore() {
+  useAppStore.setState({
+    bootstrapState: "idle",
+    error: null,
+    rootDir: null,
+    files: [],
+    fileSet: new Set(),
+    scanState: "idle",
+    scanSkippedPaths: [],
+    scanSkippedPathSet: new Set(),
+    scanError: null,
+    selectedFile: null,
+    documentLoadToken: 0,
+    isSidebarOpen: false,
+    successMessage: null,
+    successMessageId: 0,
+    document: {
+      state: "idle",
+      content: "",
+      savedContent: "",
+      draftContent: "",
+      headings: [],
+      error: null,
+      mode: "preview",
+      isDirty: false,
+      isSaving: false,
+      lastSavedAt: null,
+      externalChangeDetected: false,
+    },
+  });
+}
+
+describe("app store document safety flows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("saves the dirty draft and clears dirty state", async () => {
+    vi.mocked(readMarkdownFile).mockResolvedValue(markdownDocument("notes/a.md", "# Saved\n"));
+    vi.mocked(writeMarkdownFile).mockResolvedValue(markdownDocument("notes/a.md", "# Draft\n"));
+
+    await useAppStore.getState().openDocument("notes/a.md");
+    useAppStore.getState().updateDraftContent("# Draft\n");
+
+    expect(useAppStore.getState().document.isDirty).toBe(true);
+
+    await useAppStore.getState().saveCurrentDocument();
+
+    expect(writeMarkdownFile).toHaveBeenCalledWith("notes/a.md", "# Draft\n");
+    expect(useAppStore.getState().document).toMatchObject({
+      content: "# Draft\n",
+      savedContent: "# Draft\n",
+      draftContent: "# Draft\n",
+      isDirty: false,
+      isSaving: false,
+      error: null,
+    });
+    expect(useAppStore.getState().successMessage).toBe("저장했습니다: notes/a.md");
+  });
+
+  it("does not save over an unresolved external change", async () => {
+    vi.mocked(readMarkdownFile).mockResolvedValue(markdownDocument("notes/a.md", "# Saved\n"));
+
+    await useAppStore.getState().openDocument("notes/a.md");
+    useAppStore.getState().updateDraftContent("# Local draft\n");
+    await useAppStore.getState().reloadCurrentDocument(false);
+
+    expect(useAppStore.getState().document.externalChangeDetected).toBe(true);
+
+    await useAppStore.getState().saveCurrentDocument();
+
+    expect(writeMarkdownFile).not.toHaveBeenCalled();
+    expect(useAppStore.getState().document).toMatchObject({
+      draftContent: "# Local draft\n",
+      isDirty: true,
+      externalChangeDetected: true,
+    });
+  });
+
+  it("keeps a dirty draft when reload detects an external change without force", async () => {
+    vi.mocked(readMarkdownFile).mockResolvedValue(markdownDocument("notes/a.md", "# Saved\n"));
+
+    await useAppStore.getState().openDocument("notes/a.md");
+    useAppStore.getState().updateDraftContent("# Local draft\n");
+    vi.mocked(readMarkdownFile).mockClear();
+
+    await useAppStore.getState().reloadCurrentDocument(false);
+
+    expect(readMarkdownFile).not.toHaveBeenCalled();
+    expect(useAppStore.getState().document).toMatchObject({
+      content: "# Local draft\n",
+      draftContent: "# Local draft\n",
+      savedContent: "# Saved\n",
+      isDirty: true,
+      externalChangeDetected: true,
+    });
+  });
+
+  it("force reload discards the draft and restores disk content", async () => {
+    vi.mocked(readMarkdownFile)
+      .mockResolvedValueOnce(markdownDocument("notes/a.md", "# Saved\n"))
+      .mockResolvedValueOnce(markdownDocument("notes/a.md", "# Disk\n"));
+
+    await useAppStore.getState().openDocument("notes/a.md");
+    useAppStore.getState().updateDraftContent("# Local draft\n");
+
+    await useAppStore.getState().reloadCurrentDocument(true);
+
+    expect(readMarkdownFile).toHaveBeenLastCalledWith("notes/a.md");
+    expect(useAppStore.getState().document).toMatchObject({
+      content: "# Disk\n",
+      savedContent: "# Disk\n",
+      draftContent: "# Disk\n",
+      isDirty: false,
+      externalChangeDetected: false,
+    });
+  });
+});

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -2,10 +2,12 @@ import { create } from "zustand";
 
 import { extractHeadings } from "@/lib/markdown";
 import {
+  createMarkdownFile,
   deleteMarkdownFile,
   getInitialSession,
   readMarkdownFile,
   refreshSession,
+  renameMarkdownFile,
   writeMarkdownFile,
   type ScanProgressPayload,
 } from "@/lib/tauri";
@@ -45,6 +47,8 @@ interface AppStore {
   applyScanProgress: (payload: ScanProgressPayload) => Promise<void>;
   bootstrap: () => Promise<void>;
   openDocument: (relativePath: string) => Promise<void>;
+  createDocument: (relativePath: string, content?: string) => Promise<void>;
+  renameCurrentDocument: (toRelativePath: string) => Promise<void>;
   deleteCurrentDocument: () => Promise<void>;
   setDocumentMode: (mode: DocumentMode) => void;
   updateDraftContent: (content: string) => void;
@@ -71,11 +75,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setSidebarOpen: (open) => set({ isSidebarOpen: open }),
   applyScanProgress: async (payload) => {
     const state = get();
-    const { values: files, valueSet: fileSet } = mergeSortedUnique(
-      state.files,
-      state.fileSet,
-      payload.files,
-    );
+    const { values: files, valueSet: fileSet } = mergeSortedUnique(state.files, state.fileSet, payload.files);
     const { values: scanSkippedPaths, valueSet: scanSkippedPathSet } = mergeSortedUnique(
       state.scanSkippedPaths,
       state.scanSkippedPathSet,
@@ -167,13 +167,82 @@ export const useAppStore = create<AppStore>((set, get) => ({
       });
     }
   },
-  deleteCurrentDocument: async () => {
+  createDocument: async (relativePath, content = "") => {
+    const state = get();
+    if (state.document.isDirty && !confirmDiscardUnsavedChanges()) {
+      return;
+    }
+
+    const normalizedPath = normalizeRelativeMarkdownPath(relativePath);
+    if (!normalizedPath) {
+      return;
+    }
+
+    set({
+      error: null,
+      selectedFile: normalizedPath,
+      document: createLoadingDocument(),
+    });
+
+    try {
+      const document = await createMarkdownFile(normalizedPath, content);
+      const { values: files, valueSet: fileSet } = mergeSortedUnique(state.files, state.fileSet, [document.relativePath]);
+      set({
+        files,
+        fileSet,
+        selectedFile: document.relativePath,
+        document: {
+          ...createReadyDocument(document.content, document.headings),
+          mode: "edit",
+        },
+      });
+    } catch (error) {
+      set({
+        selectedFile: state.selectedFile,
+        document: createErrorDocument(error instanceof Error ? error.message : "문서를 생성하지 못했습니다."),
+      });
+    }
+  },
+  renameCurrentDocument: async (toRelativePath) => {
     const state = get();
     const current = state.selectedFile;
     if (!current) {
       return;
     }
-    if (!window.confirm(`정말로 \"${current}\" 문서를 삭제할까요?`)) {
+    if (state.document.isDirty && !confirmDiscardUnsavedChanges()) {
+      return;
+    }
+
+    const normalizedPath = normalizeRelativeMarkdownPath(toRelativePath);
+    if (!normalizedPath) {
+      return;
+    }
+
+    set({ document: createLoadingDocument() });
+
+    try {
+      const result = await renameMarkdownFile(current, normalizedPath);
+      const files = state.files
+        .filter((entry) => entry !== result.oldRelativePath)
+        .concat(result.document.relativePath)
+        .sort((a, b) => a.localeCompare(b));
+      set({
+        files,
+        fileSet: new Set(files),
+        selectedFile: result.document.relativePath,
+        document: createReadyDocument(result.document.content, result.document.headings),
+      });
+    } catch (error) {
+      set({
+        selectedFile: current,
+        document: createErrorDocument(error instanceof Error ? error.message : "문서 이름을 변경하지 못했습니다."),
+      });
+    }
+  },
+  deleteCurrentDocument: async () => {
+    const state = get();
+    const current = state.selectedFile;
+    if (!current) {
       return;
     }
 
@@ -419,6 +488,10 @@ function createErrorDocument(message: string): AppStore["document"] {
 
 function confirmDiscardUnsavedChanges() {
   return window.confirm("저장하지 않은 변경사항이 있습니다. 변경사항을 버리고 계속할까요?");
+}
+
+function normalizeRelativeMarkdownPath(relativePath: string) {
+  return relativePath.trim().replace(/^\/+/, "");
 }
 
 function isCurrentDocumentLoad(state: AppStore, requestPath: string, loadToken: number) {

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import { extractHeadings } from "@/lib/markdown";
 import {
+  deleteMarkdownFile,
   getInitialSession,
   readMarkdownFile,
   refreshSession,
@@ -44,6 +45,7 @@ interface AppStore {
   applyScanProgress: (payload: ScanProgressPayload) => Promise<void>;
   bootstrap: () => Promise<void>;
   openDocument: (relativePath: string) => Promise<void>;
+  deleteCurrentDocument: () => Promise<void>;
   setDocumentMode: (mode: DocumentMode) => void;
   updateDraftContent: (content: string) => void;
   saveCurrentDocument: () => Promise<void>;
@@ -162,6 +164,38 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
       set({
         document: createErrorDocument(error instanceof Error ? error.message : "문서를 열지 못했습니다."),
+      });
+    }
+  },
+  deleteCurrentDocument: async () => {
+    const state = get();
+    const current = state.selectedFile;
+    if (!current) {
+      return;
+    }
+    if (!window.confirm(`정말로 \"${current}\" 문서를 삭제할까요?`)) {
+      return;
+    }
+
+    set({ document: createLoadingDocument() });
+
+    try {
+      const result = await deleteMarkdownFile(current);
+      const files = state.files.filter((entry) => entry !== result.deletedRelativePath);
+      set({
+        files,
+        fileSet: new Set(files),
+        selectedFile: result.nextSelectedFile,
+        document: result.nextSelectedFile ? createLoadingDocument() : createEmptyDocument(),
+      });
+
+      if (result.nextSelectedFile) {
+        await get().openDocument(result.nextSelectedFile);
+      }
+    } catch (error) {
+      set({
+        selectedFile: current,
+        document: createErrorDocument(error instanceof Error ? error.message : "문서를 삭제하지 못했습니다."),
       });
     }
   },

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -136,9 +136,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
   openDocument: async (relativePath) => {
     const requestPath = relativePath;
     const current = get();
-    if (current.document.isDirty && !confirmDiscardUnsavedChanges()) {
-      return;
-    }
 
     const loadToken = current.documentLoadToken + 1;
     set({
@@ -169,9 +166,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
   createDocument: async (relativePath, content = "") => {
     const state = get();
-    if (state.document.isDirty && !confirmDiscardUnsavedChanges()) {
-      return;
-    }
 
     const normalizedPath = normalizeRelativeMarkdownPath(relativePath);
     if (!normalizedPath) {
@@ -207,9 +201,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const state = get();
     const current = state.selectedFile;
     if (!current) {
-      return;
-    }
-    if (state.document.isDirty && !confirmDiscardUnsavedChanges()) {
       return;
     }
 
@@ -389,10 +380,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const previousSelection = previousState.selectedFile;
     const hadDirtyDocument = previousState.document.isDirty;
 
-    if (hadDirtyDocument && !confirmDiscardUnsavedChanges()) {
-      return;
-    }
-
     try {
       const session = await refreshSession();
       const { values: files, valueSet: fileSet } = mergeSortedUnique([], new Set(), session.files);
@@ -484,10 +471,6 @@ function createErrorDocument(message: string): AppStore["document"] {
     state: "error",
     error: message,
   };
-}
-
-function confirmDiscardUnsavedChanges() {
-  return window.confirm("저장하지 않은 변경사항이 있습니다. 변경사항을 버리고 계속할까요?");
 }
 
 function normalizeRelativeMarkdownPath(relativePath: string) {

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -30,6 +30,8 @@ interface AppStore {
   selectedFile: string | null;
   documentLoadToken: number;
   isSidebarOpen: boolean;
+  successMessage: string | null;
+  successMessageId: number;
   document: {
     state: DocumentState;
     content: string;
@@ -44,6 +46,7 @@ interface AppStore {
     externalChangeDetected: boolean;
   };
   setSidebarOpen: (open: boolean) => void;
+  clearSuccessMessage: () => void;
   applyScanProgress: (payload: ScanProgressPayload) => Promise<void>;
   bootstrap: () => Promise<void>;
   openDocument: (relativePath: string) => Promise<void>;
@@ -71,8 +74,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
   selectedFile: null,
   documentLoadToken: 0,
   isSidebarOpen: false,
+  successMessage: null,
+  successMessageId: 0,
   document: createEmptyDocument(),
   setSidebarOpen: (open) => set({ isSidebarOpen: open }),
+  clearSuccessMessage: () => set({ successMessage: null }),
   applyScanProgress: async (payload) => {
     const state = get();
     const { values: files, valueSet: fileSet } = mergeSortedUnique(state.files, state.fileSet, payload.files);
@@ -152,6 +158,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
       set({
         selectedFile: document.relativePath,
+        successMessage: null,
         document: createReadyDocument(document.content, document.headings),
       });
     } catch (error) {
@@ -181,15 +188,17 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const document = await createMarkdownFile(normalizedPath, content);
       const { values: files, valueSet: fileSet } = mergeSortedUnique(state.files, state.fileSet, [document.relativePath]);
-      set({
+      set((state) => ({
         files,
         fileSet,
         selectedFile: document.relativePath,
+        successMessage: `새 문서를 만들었습니다: ${document.relativePath}`,
+        successMessageId: state.successMessageId + 1,
         document: {
           ...createReadyDocument(document.content, document.headings),
           mode: "edit",
         },
-      });
+      }));
     } catch (error) {
       set({
         selectedFile: state.selectedFile,
@@ -217,12 +226,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
         .filter((entry) => entry !== result.oldRelativePath)
         .concat(result.document.relativePath)
         .sort((a, b) => a.localeCompare(b));
-      set({
+      set((state) => ({
         files,
         fileSet: new Set(files),
         selectedFile: result.document.relativePath,
+        successMessage: `문서 이름을 변경했습니다: ${result.document.relativePath}`,
+        successMessageId: state.successMessageId + 1,
         document: createReadyDocument(result.document.content, result.document.headings),
-      });
+      }));
     } catch (error) {
       set({
         selectedFile: current,
@@ -242,12 +253,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const result = await deleteMarkdownFile(current);
       const files = state.files.filter((entry) => entry !== result.deletedRelativePath);
-      set({
+      set((state) => ({
         files,
         fileSet: new Set(files),
         selectedFile: result.nextSelectedFile,
+        successMessage: `문서를 삭제했습니다: ${result.deletedRelativePath}`,
+        successMessageId: state.successMessageId + 1,
         document: result.nextSelectedFile ? createLoadingDocument() : createEmptyDocument(),
-      });
+      }));
 
       if (result.nextSelectedFile) {
         await get().openDocument(result.nextSelectedFile);
@@ -269,6 +282,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
   updateDraftContent: (content) => {
     set((state) => ({
+      successMessage: null,
       document: {
         ...state.document,
         content,
@@ -303,14 +317,16 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     try {
       const document = await writeMarkdownFile(current, draftContent);
-      set({
+      set((state) => ({
         selectedFile: document.relativePath,
+        successMessage: `저장했습니다: ${document.relativePath}`,
+        successMessageId: state.successMessageId + 1,
         document: {
           ...createReadyDocument(document.content, document.headings),
           mode: get().document.mode,
           lastSavedAt: new Date().toISOString(),
         },
-      });
+      }));
     } catch (error) {
       set((state) => ({
         document: {
@@ -351,6 +367,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }
 
       set((state) => ({
+        successMessage: null,
         selectedFile: document.relativePath,
         document: {
           ...createReadyDocument(document.content, document.headings),
@@ -393,6 +410,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         scanSkippedPaths: [],
         scanSkippedPathSet: new Set(),
         scanError: null,
+        successMessage: null,
       });
 
       if (previousSelection && session.files.includes(previousSelection)) {

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -18,6 +18,11 @@ export interface MarkdownDocument {
   headings: HeadingItem[];
 }
 
+export interface RenameMarkdownResult {
+  oldRelativePath: string;
+  document: MarkdownDocument;
+}
+
 export interface DeleteMarkdownResult {
   deletedRelativePath: string;
   nextSelectedFile: string | null;

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -17,3 +17,8 @@ export interface MarkdownDocument {
   content: string;
   headings: HeadingItem[];
 }
+
+export interface DeleteMarkdownResult {
+  deletedRelativePath: string;
+  nextSelectedFile: string | null;
+}


### PR DESCRIPTION
## Summary
- add Vitest as the minimal frontend test runner
- add document safety store coverage for dirty save, external-change save blocking, non-force reload, and force reload
- document `pnpm test` in the verification commands

## Validation
- pnpm test
- pnpm typecheck
- cargo check --manifest-path src-tauri/Cargo.toml
- pnpm build

Closes #41