### PR TITLE
fix: contain wide markdown preview content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,8 +117,8 @@ function App() {
               </div>
             </aside>
 
-            <section className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
-              <Card className="min-h-[70vh] overflow-hidden">
+            <section className="grid min-h-0 min-w-0 gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
+              <Card className="min-h-[70vh] min-w-0 overflow-hidden">
                 <CardContent className="flex h-full flex-col p-0">
                   <div className="border-b border-border/60 px-5 py-4">
                     <div className="flex items-center gap-2 text-sm font-medium uppercase tracking-widest text-muted-foreground">

--- a/src/components/markdown-view.tsx
+++ b/src/components/markdown-view.tsx
@@ -46,7 +46,7 @@ const MERMAID_START_KEYWORDS = new Set([
 ]);
 
 const markdownClassName = [
-  "prose prose-slate mx-auto w-full max-w-none px-5 py-8 text-foreground sm:px-8 sm:py-10",
+  "prose prose-slate mx-auto w-full max-w-none overflow-x-hidden px-5 py-8 text-foreground sm:px-8 sm:py-10",
   "prose-headings:scroll-mt-24 prose-headings:font-display prose-headings:text-primary prose-headings:focus:outline-none prose-headings:focus-visible:ring-2 prose-headings:focus-visible:ring-ring",
   "prose-h1:mt-0 prose-h1:text-4xl prose-h1:leading-tight",
   "prose-h2:mt-12 prose-h2:text-2xl prose-h2:leading-tight",
@@ -56,8 +56,6 @@ const markdownClassName = [
   "prose-strong:text-primary prose-code:rounded-md prose-code:bg-secondary prose-code:px-1.5 prose-code:py-0.5 prose-code:text-primary",
   "prose-pre:overflow-x-auto prose-pre:rounded-lg prose-pre:border prose-pre:border-border prose-pre:bg-primary prose-pre:text-sm prose-pre:text-primary-foreground prose-pre:shadow-inner",
   "prose-blockquote:border-accent prose-blockquote:bg-background prose-blockquote:px-4 prose-blockquote:py-1 prose-blockquote:font-normal prose-blockquote:italic",
-  "prose-table:my-6 prose-table:w-full prose-table:overflow-hidden prose-table:rounded-lg prose-table:border prose-table:border-border prose-table:bg-background",
-  "prose-thead:bg-secondary prose-th:border-b prose-th:border-border prose-th:px-4 prose-th:py-3 prose-td:border-b prose-td:border-border prose-td:px-4 prose-td:py-3",
   "prose-hr:border-border",
   "[&_code::after]:content-none [&_code::before]:content-none [&_pre_code]:rounded-none [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:font-normal [&_pre_code]:text-inherit",
 ].join(" ");
@@ -75,7 +73,7 @@ export function MarkdownView({ content, currentRelativePath, knownDocuments, onN
   const createHeadingId = createSlugger();
 
   return (
-    <ScrollArea className="h-[calc(100vh-13rem)]">
+    <ScrollArea className="h-[calc(100vh-13rem)] min-w-0">
       <div className={markdownClassName}>
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
@@ -128,6 +126,16 @@ export function MarkdownView({ content, currentRelativePath, knownDocuments, onN
               </a>
             );
           },
+          table: ({ children }) => (
+            <div className="not-prose my-6 max-w-full overflow-x-auto rounded-lg border border-border bg-background">
+              <table className="w-max min-w-full border-collapse text-sm">{children}</table>
+            </div>
+          ),
+          thead: ({ children }) => <thead className="bg-secondary">{children}</thead>,
+          th: ({ children }) => (
+            <th className="border-b border-border px-4 py-3 text-left font-semibold text-primary">{children}</th>
+          ),
+          td: ({ children }) => <td className="border-b border-border px-4 py-3 align-top">{children}</td>,
           pre: ({ children }) => {
             const child = Array.isArray(children) ? children[0] : children;
             if (child && typeof child === "object" && "props" in child) {
@@ -142,7 +150,7 @@ export function MarkdownView({ content, currentRelativePath, knownDocuments, onN
               }
             }
 
-            return <pre>{children}</pre>;
+            return <pre className="max-w-full overflow-x-auto">{children}</pre>;
           },
           code: ({ className, children }) => <code className={className}>{children}</code>,
           h1: ({ children }) => {

--- a/src/components/mermaid-block.tsx
+++ b/src/components/mermaid-block.tsx
@@ -4,7 +4,7 @@ interface MermaidBlockProps {
   chart: string;
 }
 
-const shellClassName = "not-prose my-6 overflow-hidden rounded-lg border border-border bg-background p-4 shadow-sm";
+const shellClassName = "not-prose my-6 max-w-full overflow-x-auto rounded-lg border border-border bg-background p-4 shadow-sm";
 
 export function MermaidBlock({ chart }: MermaidBlockProps) {
   const reactId = useId();
@@ -62,5 +62,10 @@ export function MermaidBlock({ chart }: MermaidBlockProps) {
     return <div className={`${shellClassName} text-sm text-muted-foreground`}>Mermaid chart 렌더링 중...</div>;
   }
 
-  return <div className={`${shellClassName} [&_svg]:h-auto [&_svg]:max-w-full`} dangerouslySetInnerHTML={{ __html: svg }} />;
+  return (
+    <div
+      className={`${shellClassName} [&_svg]:mx-auto [&_svg]:block [&_svg]:h-auto [&_svg]:max-w-full`}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- constrain reader grid/card columns with `min-w-0` so wide preview content does not push sibling layout
- wrap markdown tables in a bounded horizontal-scroll container
- keep code blocks horizontally scrollable
- make Mermaid blocks scale SVGs to the available preview width while allowing fallback horizontal scroll

## Validation
- pnpm test
- pnpm typecheck
- pnpm build

Closes #105