### PR TITLE
feat: float table of contents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,8 +117,8 @@ function App() {
               </div>
             </aside>
 
-            <section className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
-              <Card className="min-h-[70vh] overflow-hidden">
+            <section className="relative min-h-0 min-w-0 xl:pr-[296px]">
+              <Card className="min-h-[70vh] min-w-0 overflow-hidden">
                 <CardContent className="flex h-full flex-col p-0">
                   <div className="border-b border-border/60 px-5 py-4">
                     <div className="flex items-center gap-2 text-sm font-medium uppercase tracking-widest text-muted-foreground">
@@ -149,8 +149,8 @@ function App() {
                 </CardContent>
               </Card>
 
-              <aside className="min-h-0">
-                <div className="sticky top-4">
+              <aside className="hidden xl:block">
+                <div className="fixed right-[max(1.5rem,calc((100vw-1600px)/2+1.5rem))] top-28 z-20 w-[280px]">
                   {scanError ? (
                     <div className="mb-4 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
                       {scanError}

--- a/src/components/table-of-contents.tsx
+++ b/src/components/table-of-contents.tsx
@@ -75,7 +75,7 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
 
   if (headings.length === 0) {
     return (
-      <Card>
+      <Card className="bg-card/95 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-card/85">
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-lg">
             <ListTree className="h-4 w-4" />
@@ -88,7 +88,7 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
   }
 
   return (
-    <Card>
+    <Card className="bg-card/95 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-card/85">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-lg">
           <ListTree className="h-4 w-4" />
@@ -96,7 +96,7 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
         </CardTitle>
       </CardHeader>
       <CardContent className="pt-0">
-        <ScrollArea className="h-[min(60vh,calc(100vh-14rem))] pr-3" viewportRef={scrollViewportRef}>
+        <ScrollArea className="h-[min(62vh,calc(100vh-15rem))] pr-3" viewportRef={scrollViewportRef}>
           <div>
             <nav aria-label="Table of contents">
               <ol className="space-y-1">


### PR DESCRIPTION
## Summary
- move the TOC into a fixed floating desktop rail with reserved reader padding to avoid covering content
- hide the TOC rail below the xl breakpoint so mobile reading keeps full width
- add card shadow/backdrop treatment and a bounded TOC scroll height for long documents
- preserve active-heading highlighting and heading click navigation

## Validation
- pnpm test
- pnpm typecheck
- pnpm build

Closes #106