### PR TITLE
feat: persist document tree filter query

### DIFF
--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { buildTree, filterFiles, flattenVisibleTree, treeNodeIndent } from "./file-tree";
+import {
+  DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY,
+  buildTree,
+  filterFiles,
+  flattenVisibleTree,
+  readStoredSearchQuery,
+  treeNodeIndent,
+  writeStoredSearchQuery,
+} from "./file-tree";
 
 const files = ["docs/guide.md", "notes/today.md", "projects/markmini/plan.md"];
 
@@ -41,6 +49,45 @@ describe("document tree filtering", () => {
     ]);
   });
 });
+
+describe("document tree search query persistence", () => {
+  it("stores and restores the query in session storage", () => {
+    const sessionStorage = installSessionStorageMock();
+    window.sessionStorage.clear();
+
+    writeStoredSearchQuery("markmini");
+
+    expect(sessionStorage.getItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY)).toBe("markmini");
+    expect(readStoredSearchQuery()).toBe("markmini");
+  });
+
+  it("removes the stored query when the query is cleared", () => {
+    const sessionStorage = installSessionStorageMock();
+    sessionStorage.setItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY, "guide");
+
+    writeStoredSearchQuery("");
+
+    expect(sessionStorage.getItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY)).toBeNull();
+    expect(readStoredSearchQuery()).toBe("");
+  });
+});
+
+function installSessionStorageMock() {
+  const values = new Map<string, string>();
+  const sessionStorage = {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+
+  Object.defineProperty(globalThis, "window", {
+    value: { sessionStorage },
+    configurable: true,
+  });
+
+  return sessionStorage;
+}
 
 describe("file tree structure", () => {
   it("preserves every parent directory for deeply nested markdown files", () => {

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -15,8 +15,10 @@ interface FileTreeProps {
   onSelect: (relativePath: string) => void;
 }
 
+export const DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY = "markmini.documentTree.searchQuery";
+
 export function FileTree({ files, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState(readStoredSearchQuery);
   const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredFiles = useMemo(() => filterFiles(files, normalizedSearchQuery), [files, normalizedSearchQuery]);
   const tree = useMemo(() => buildTree(filteredFiles), [filteredFiles]);
@@ -26,6 +28,10 @@ export function FileTree({ files, scanState, skippedCount, selectedFile, onSelec
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set());
   const [focusedPath, setFocusedPath] = useState<string | null>(selectedFile);
   const treeRef = useRef<HTMLUListElement | null>(null);
+
+  useEffect(() => {
+    writeStoredSearchQuery(searchQuery);
+  }, [searchQuery]);
 
   useEffect(() => {
     setExpandedPaths((current) => {
@@ -369,6 +375,34 @@ export function filterFiles(files: string[], normalizedSearchQuery: string) {
     const normalizedLabel = fileLabel(file).toLocaleLowerCase();
     return normalizedPath.includes(normalizedSearchQuery) || normalizedLabel.includes(normalizedSearchQuery);
   });
+}
+
+export function readStoredSearchQuery() {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  try {
+    return window.sessionStorage.getItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function writeStoredSearchQuery(searchQuery: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    if (searchQuery) {
+      window.sessionStorage.setItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY, searchQuery);
+    } else {
+      window.sessionStorage.removeItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore storage failures so the document tree remains usable in restricted contexts.
+  }
 }
 
 export function buildTree(files: string[]) {


### PR DESCRIPTION
## Summary
- restore the document tree search query from per-window session storage
- persist query changes while clearing storage when the query is empty
- cover storage read/write behavior with focused tests

## Validation
- pnpm test
- pnpm typecheck
- pnpm build

Closes #55