### PR TITLE
feat: add document search clear affordances

### DIFF
--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -6,6 +6,7 @@ import {
   filterFiles,
   flattenVisibleTree,
   readStoredSearchQuery,
+  shouldShowSearchClearButton,
   treeNodeIndent,
   writeStoredSearchQuery,
 } from "./file-tree";
@@ -69,6 +70,13 @@ describe("document tree search query persistence", () => {
 
     expect(sessionStorage.getItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY)).toBeNull();
     expect(readStoredSearchQuery()).toBe("");
+  });
+});
+
+describe("document tree search affordances", () => {
+  it("shows the clear affordance only while there is query text", () => {
+    expect(shouldShowSearchClearButton("")).toBe(false);
+    expect(shouldShowSearchClearButton("guide")).toBe(true);
   });
 });
 

--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { buildTree, filterFiles, flattenVisibleTree, treeNodeIndent } from "./file-tree";
+import {
+  DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY,
+  buildTree,
+  filterFiles,
+  flattenVisibleTree,
+  readStoredSearchQuery,
+  treeNodeIndent,
+  writeStoredSearchQuery,
+} from "./file-tree";
 
 const files = ["docs/guide.md", "notes/today.md", "projects/markmini/plan.md"];
 
@@ -41,6 +49,45 @@ describe("document tree filtering", () => {
     ]);
   });
 });
+
+describe("document tree search query persistence", () => {
+  it("stores and restores the query in session storage", () => {
+    const sessionStorage = installSessionStorageMock();
+    window.sessionStorage.clear();
+
+    writeStoredSearchQuery("markmini");
+
+    expect(sessionStorage.getItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY)).toBe("markmini");
+    expect(readStoredSearchQuery()).toBe("markmini");
+  });
+
+  it("removes the stored query when the query is cleared", () => {
+    const sessionStorage = installSessionStorageMock();
+    sessionStorage.setItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY, "guide");
+
+    writeStoredSearchQuery("");
+
+    expect(sessionStorage.getItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY)).toBeNull();
+    expect(readStoredSearchQuery()).toBe("");
+  });
+});
+
+function installSessionStorageMock() {
+  const values = new Map<string, string>();
+  const sessionStorage = {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+
+  Object.defineProperty(globalThis, "window", {
+    value: { sessionStorage },
+    configurable: true,
+  });
+
+  return sessionStorage;
+}
 
 describe("file tree structure", () => {
   it("preserves every parent directory for deeply nested markdown files", () => {

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -15,8 +15,10 @@ interface FileTreeProps {
   onSelect: (relativePath: string) => void;
 }
 
+export const DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY = "markmini.documentTree.searchQuery";
+
 export function FileTree({ files, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState(readStoredSearchQuery);
   const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredFiles = useMemo(() => filterFiles(files, normalizedSearchQuery), [files, normalizedSearchQuery]);
   const tree = useMemo(() => buildTree(filteredFiles), [filteredFiles]);
@@ -26,6 +28,10 @@ export function FileTree({ files, scanState, skippedCount, selectedFile, onSelec
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set());
   const [focusedPath, setFocusedPath] = useState<string | null>(selectedFile);
   const treeRef = useRef<HTMLUListElement | null>(null);
+
+  useEffect(() => {
+    writeStoredSearchQuery(searchQuery);
+  }, [searchQuery]);
 
   useEffect(() => {
     setExpandedPaths((current) => {
@@ -369,6 +375,34 @@ export function filterFiles(files: string[], normalizedSearchQuery: string) {
     const normalizedLabel = fileLabel(file).toLocaleLowerCase();
     return normalizedPath.includes(normalizedSearchQuery) || normalizedLabel.includes(normalizedSearchQuery);
   });
+}
+
+export function readStoredSearchQuery() {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  try {
+    return window.sessionStorage.getItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function writeStoredSearchQuery(searchQuery: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    if (searchQuery) {
+      window.sessionStorage.setItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY, searchQuery);
+    } else {
+      window.sessionStorage.removeItem(DOCUMENT_TREE_SEARCH_QUERY_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore storage failures so the document tree remains usable in restricted contexts.
+  }
 }
 
 export function buildTree(files: string[]) {

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -1,5 +1,5 @@
 import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, ChevronRight, FileText, Folder, FolderOpen, Search } from "lucide-react";
+import { ChevronDown, ChevronRight, FileText, Folder, FolderOpen, Search, X } from "lucide-react";
 
 import { fileLabel } from "@/lib/path";
 import { cn } from "@/lib/utils";
@@ -28,6 +28,8 @@ export function FileTree({ files, scanState, skippedCount, selectedFile, onSelec
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set());
   const [focusedPath, setFocusedPath] = useState<string | null>(selectedFile);
   const treeRef = useRef<HTMLUListElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const showSearchClearButton = shouldShowSearchClearButton(searchQuery);
 
   useEffect(() => {
     writeStoredSearchQuery(searchQuery);
@@ -172,13 +174,33 @@ export function FileTree({ files, scanState, skippedCount, selectedFile, onSelec
         <div className="relative mt-3">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <input
+            ref={searchInputRef}
             type="search"
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape" && searchQuery) {
+                event.preventDefault();
+                setSearchQuery("");
+              }
+            }}
             placeholder="문서 검색"
             aria-label="문서 검색"
-            className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm text-foreground outline-none transition placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-10 text-sm text-foreground outline-none transition placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           />
+          {showSearchClearButton ? (
+            <button
+              type="button"
+              aria-label="문서 검색어 지우기"
+              className="absolute right-2 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={() => {
+                setSearchQuery("");
+                searchInputRef.current?.focus();
+              }}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          ) : null}
         </div>
         {scanState === "scanning" || skippedCount > 0 ? (
           <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
@@ -375,6 +397,10 @@ export function filterFiles(files: string[], normalizedSearchQuery: string) {
     const normalizedLabel = fileLabel(file).toLocaleLowerCase();
     return normalizedPath.includes(normalizedSearchQuery) || normalizedLabel.includes(normalizedSearchQuery);
   });
+}
+
+export function shouldShowSearchClearButton(searchQuery: string) {
+  return searchQuery.length > 0;
 }
 
 export function readStoredSearchQuery() {


### PR DESCRIPTION
## Summary
- add an inline clear button for the document tree search field
- support Escape to clear the current query from the search input
- keep focus on the search field after clearing
- cover clear affordance visibility with focused tests

## Validation
- pnpm test
- pnpm typecheck
- pnpm build

Stacked after #113.
Closes #57