### PR TITLE
feat: add recent documents section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ function App() {
   const error = useAppStore((state) => state.error);
   const rootDir = useAppStore((state) => state.rootDir);
   const files = useAppStore((state) => state.files);
+  const recentDocuments = useAppStore((state) => state.recentDocuments);
   const scanState = useAppStore((state) => state.scanState);
   const scanSkippedPaths = useAppStore((state) => state.scanSkippedPaths);
   const scanError = useAppStore((state) => state.scanError);
@@ -79,6 +80,7 @@ function App() {
                   <div className="h-[calc(100vh-72px)] overflow-hidden">
                     <FileTree
                       files={files}
+                      recentDocuments={recentDocuments}
                       scanState={scanState}
                       skippedCount={scanSkippedPaths.length}
                       selectedFile={selectedFile}
@@ -109,6 +111,7 @@ function App() {
               <div className="sticky top-4 h-[calc(100vh-8rem)]">
                 <FileTree
                   files={files}
+                  recentDocuments={recentDocuments}
                   scanState={scanState}
                   skippedCount={scanSkippedPaths.length}
                   selectedFile={selectedFile}

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -9,13 +9,14 @@ import type { ScanStatus } from "@/types/content";
 
 interface FileTreeProps {
   files: string[];
+  recentDocuments: string[];
   scanState: ScanStatus;
   skippedCount: number;
   selectedFile: string | null;
   onSelect: (relativePath: string) => void;
 }
 
-export function FileTree({ files, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
+export function FileTree({ files, recentDocuments, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredFiles = useMemo(() => filterFiles(files, normalizedSearchQuery), [files, normalizedSearchQuery]);
@@ -184,6 +185,29 @@ export function FileTree({ files, scanState, skippedCount, selectedFile, onSelec
       <CardContent className="min-h-0 flex-1 p-0">
         <ScrollArea className="h-full">
           <div className="px-2 py-3">
+            {recentDocuments.length > 0 ? (
+              <div className="mb-3 border-b border-border/60 pb-3">
+                <p className="px-2 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">Recent</p>
+                <div className="mt-2 space-y-0.5">
+                  {recentDocuments.map((path) => (
+                    <button
+                      key={path}
+                      type="button"
+                      className={cn(
+                        "flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+                        selectedFile === path
+                          ? "bg-primary text-primary-foreground shadow-sm"
+                          : "text-foreground hover:bg-accent hover:text-accent-foreground",
+                      )}
+                      onClick={() => onSelect(path)}
+                    >
+                      <FileText className={cn("h-4 w-4 shrink-0", selectedFile === path ? "opacity-90" : "text-muted-foreground")} />
+                      <span className="truncate">{fileLabel(path)}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
             {selectedFileIsFilteredOut ? (
               <div className="mb-3 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs leading-5 text-muted-foreground">
                 현재 선택된 문서는 검색 결과에 없습니다. 검색어를 지우면 다시 표시됩니다.

--- a/src/store/app-store.test.ts
+++ b/src/store/app-store.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getInitialSession, readMarkdownFile, refreshSession } from "@/lib/tauri";
-import { useAppStore } from "@/store/app-store";
+import { addRecentDocument, pruneDocumentList, useAppStore } from "@/store/app-store";
 import type { HeadingItem, MarkdownDocument } from "@/types/content";
 
 vi.mock("@/lib/tauri", () => ({
@@ -38,6 +38,7 @@ function resetStore() {
     rootDir: null,
     files: [],
     fileSet: new Set(),
+    recentDocuments: [],
     scanState: "idle",
     scanSkippedPaths: [],
     scanSkippedPathSet: new Set(),
@@ -77,6 +78,7 @@ describe("viewer app store", () => {
       rootDir: "/vault",
       files: ["notes/a.md"],
       selectedFile: "notes/a.md",
+      recentDocuments: ["notes/a.md"],
     });
     expect(useAppStore.getState().document).toMatchObject({
       state: "ready",
@@ -155,5 +157,35 @@ describe("viewer app store", () => {
       state: "ready",
       content: "# Existing\n",
     });
+  });
+
+  it("tracks recently opened documents without duplicates", async () => {
+    useAppStore.setState({ files: ["notes/a.md", "notes/b.md"], fileSet: new Set(["notes/a.md", "notes/b.md"]) });
+    vi.mocked(readMarkdownFile)
+      .mockResolvedValueOnce(markdownDocument("notes/a.md", "# A\n"))
+      .mockResolvedValueOnce(markdownDocument("notes/b.md", "# B\n"))
+      .mockResolvedValueOnce(markdownDocument("notes/a.md", "# A again\n"));
+
+    await useAppStore.getState().openDocument("notes/a.md");
+    await useAppStore.getState().openDocument("notes/b.md");
+    await useAppStore.getState().openDocument("notes/a.md");
+
+    expect(useAppStore.getState().recentDocuments).toEqual(["notes/a.md", "notes/b.md"]);
+  });
+});
+
+describe("recent document helpers", () => {
+  it("adds available documents most-recent-first and enforces a limit", () => {
+    const availableFiles = new Set(["a.md", "b.md", "c.md"]);
+
+    expect(addRecentDocument(["b.md", "c.md"], "a.md", availableFiles, 2)).toEqual(["a.md", "b.md"]);
+    expect(addRecentDocument(["a.md", "b.md"], "a.md", availableFiles)).toEqual(["a.md", "b.md"]);
+  });
+
+  it("prunes stale and duplicate document paths", () => {
+    expect(pruneDocumentList(["a.md", "missing.md", "a.md", "b.md"], new Set(["a.md", "b.md"]))).toEqual([
+      "a.md",
+      "b.md",
+    ]);
   });
 });

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -13,6 +13,7 @@ interface AppStore {
   rootDir: string | null;
   files: string[];
   fileSet: ReadonlySet<string>;
+  recentDocuments: string[];
   scanState: ScanStatus;
   scanSkippedPaths: string[];
   scanSkippedPathSet: ReadonlySet<string>;
@@ -40,6 +41,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   rootDir: null,
   files: [],
   fileSet: new Set(),
+  recentDocuments: [],
   scanState: "idle",
   scanSkippedPaths: [],
   scanSkippedPathSet: new Set(),
@@ -100,6 +102,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         rootDir: session.rootDir,
         files,
         fileSet,
+        recentDocuments: pruneDocumentList(get().recentDocuments, fileSet),
         selectedFile: session.selectedFile,
       });
 
@@ -129,6 +132,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
       set({
         selectedFile: document.relativePath,
+        recentDocuments: addRecentDocument(get().recentDocuments, document.relativePath, get().fileSet),
         document: createReadyDocument(document.content, document.headings),
       });
     } catch (error) {
@@ -182,6 +186,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         rootDir: session.rootDir,
         files,
         fileSet,
+        recentDocuments: pruneDocumentList(previousState.recentDocuments, fileSet),
         selectedFile,
         scanState: "completed",
       });
@@ -258,4 +263,16 @@ function mergeSortedUnique(current: string[], currentSet: ReadonlySet<string>, i
   }
 
   return { values: [...next].sort(), valueSet: next };
+}
+
+export function addRecentDocument(current: string[], documentPath: string, availableFiles: ReadonlySet<string>, limit = 5) {
+  if (!availableFiles.has(documentPath)) {
+    return current;
+  }
+
+  return [documentPath, ...current.filter((path) => path !== documentPath && availableFiles.has(path))].slice(0, limit);
+}
+
+export function pruneDocumentList(paths: string[], availableFiles: ReadonlySet<string>, limit = 5) {
+  return paths.filter((path, index) => index === paths.indexOf(path) && availableFiles.has(path)).slice(0, limit);
 }


### PR DESCRIPTION
## Summary
- track recently opened markdown files in app/window state
- show a compact Recent section above the document tree
- keep recent entries deduplicated, short, and pruned to files in the current root
- add store/helper tests for recent document behavior

## Validation
- pnpm test
- pnpm typecheck
- pnpm build

Closes #61