### PR TITLE
feat: persist recent documents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ function App() {
   const error = useAppStore((state) => state.error);
   const rootDir = useAppStore((state) => state.rootDir);
   const files = useAppStore((state) => state.files);
+  const recentDocuments = useAppStore((state) => state.recentDocuments);
   const scanState = useAppStore((state) => state.scanState);
   const scanSkippedPaths = useAppStore((state) => state.scanSkippedPaths);
   const scanError = useAppStore((state) => state.scanError);
@@ -79,6 +80,7 @@ function App() {
                   <div className="h-[calc(100vh-72px)] overflow-hidden">
                     <FileTree
                       files={files}
+                      recentDocuments={recentDocuments}
                       scanState={scanState}
                       skippedCount={scanSkippedPaths.length}
                       selectedFile={selectedFile}
@@ -109,6 +111,7 @@ function App() {
               <div className="sticky top-4 h-[calc(100vh-8rem)]">
                 <FileTree
                   files={files}
+                  recentDocuments={recentDocuments}
                   scanState={scanState}
                   skippedCount={scanSkippedPaths.length}
                   selectedFile={selectedFile}

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -9,13 +9,14 @@ import type { ScanStatus } from "@/types/content";
 
 interface FileTreeProps {
   files: string[];
+  recentDocuments: string[];
   scanState: ScanStatus;
   skippedCount: number;
   selectedFile: string | null;
   onSelect: (relativePath: string) => void;
 }
 
-export function FileTree({ files, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
+export function FileTree({ files, recentDocuments, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredFiles = useMemo(() => filterFiles(files, normalizedSearchQuery), [files, normalizedSearchQuery]);
@@ -184,6 +185,29 @@ export function FileTree({ files, scanState, skippedCount, selectedFile, onSelec
       <CardContent className="min-h-0 flex-1 p-0">
         <ScrollArea className="h-full">
           <div className="px-2 py-3">
+            {recentDocuments.length > 0 ? (
+              <div className="mb-3 border-b border-border/60 pb-3">
+                <p className="px-2 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">Recent</p>
+                <div className="mt-2 space-y-0.5">
+                  {recentDocuments.map((path) => (
+                    <button
+                      key={path}
+                      type="button"
+                      className={cn(
+                        "flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+                        selectedFile === path
+                          ? "bg-primary text-primary-foreground shadow-sm"
+                          : "text-foreground hover:bg-accent hover:text-accent-foreground",
+                      )}
+                      onClick={() => onSelect(path)}
+                    >
+                      <FileText className={cn("h-4 w-4 shrink-0", selectedFile === path ? "opacity-90" : "text-muted-foreground")} />
+                      <span className="truncate">{fileLabel(path)}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
             {selectedFileIsFilteredOut ? (
               <div className="mb-3 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs leading-5 text-muted-foreground">
                 현재 선택된 문서는 검색 결과에 없습니다. 검색어를 지우면 다시 표시됩니다.

--- a/src/store/app-store.test.ts
+++ b/src/store/app-store.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getInitialSession, readMarkdownFile, refreshSession } from "@/lib/tauri";
-import { useAppStore } from "@/store/app-store";
+import { addRecentDocument, pruneDocumentList, useAppStore } from "@/store/app-store";
 import type { HeadingItem, MarkdownDocument } from "@/types/content";
 
 vi.mock("@/lib/tauri", () => ({
@@ -38,6 +38,7 @@ function resetStore() {
     rootDir: null,
     files: [],
     fileSet: new Set(),
+    recentDocuments: [],
     scanState: "idle",
     scanSkippedPaths: [],
     scanSkippedPathSet: new Set(),
@@ -77,6 +78,7 @@ describe("viewer app store", () => {
       rootDir: "/vault",
       files: ["notes/a.md"],
       selectedFile: "notes/a.md",
+      recentDocuments: ["notes/a.md"],
     });
     expect(useAppStore.getState().document).toMatchObject({
       state: "ready",
@@ -155,5 +157,35 @@ describe("viewer app store", () => {
       state: "ready",
       content: "# Existing\n",
     });
+  });
+
+  it("tracks recently opened documents without duplicates", async () => {
+    useAppStore.setState({ files: ["notes/a.md", "notes/b.md"], fileSet: new Set(["notes/a.md", "notes/b.md"]) });
+    vi.mocked(readMarkdownFile)
+      .mockResolvedValueOnce(markdownDocument("notes/a.md", "# A\n"))
+      .mockResolvedValueOnce(markdownDocument("notes/b.md", "# B\n"))
+      .mockResolvedValueOnce(markdownDocument("notes/a.md", "# A again\n"));
+
+    await useAppStore.getState().openDocument("notes/a.md");
+    await useAppStore.getState().openDocument("notes/b.md");
+    await useAppStore.getState().openDocument("notes/a.md");
+
+    expect(useAppStore.getState().recentDocuments).toEqual(["notes/a.md", "notes/b.md"]);
+  });
+});
+
+describe("recent document helpers", () => {
+  it("adds available documents most-recent-first and enforces a limit", () => {
+    const availableFiles = new Set(["a.md", "b.md", "c.md"]);
+
+    expect(addRecentDocument(["b.md", "c.md"], "a.md", availableFiles, 2)).toEqual(["a.md", "b.md"]);
+    expect(addRecentDocument(["a.md", "b.md"], "a.md", availableFiles)).toEqual(["a.md", "b.md"]);
+  });
+
+  it("prunes stale and duplicate document paths", () => {
+    expect(pruneDocumentList(["a.md", "missing.md", "a.md", "b.md"], new Set(["a.md", "b.md"]))).toEqual([
+      "a.md",
+      "b.md",
+    ]);
   });
 });

--- a/src/store/app-store.test.ts
+++ b/src/store/app-store.test.ts
@@ -1,7 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getInitialSession, readMarkdownFile, refreshSession } from "@/lib/tauri";
-import { addRecentDocument, pruneDocumentList, useAppStore } from "@/store/app-store";
+import {
+  RECENT_DOCUMENTS_STORAGE_KEY_PREFIX,
+  addRecentDocument,
+  pruneDocumentList,
+  readStoredRecentDocuments,
+  recentDocumentsStorageKey,
+  useAppStore,
+  writeStoredRecentDocuments,
+} from "@/store/app-store";
 import type { HeadingItem, MarkdownDocument } from "@/types/content";
 
 vi.mock("@/lib/tauri", () => ({
@@ -86,6 +94,20 @@ describe("viewer app store", () => {
       headings: [heading],
       error: null,
     });
+  });
+
+  it("restores persisted recent documents during bootstrap", async () => {
+    const localStorage = installLocalStorageMock();
+    localStorage.setItem(recentDocumentsStorageKey("/vault"), JSON.stringify(["notes/b.md", "missing.md"]));
+    vi.mocked(getInitialSession).mockResolvedValue({
+      rootDir: "/vault",
+      files: ["notes/a.md", "notes/b.md"],
+      selectedFile: null,
+    });
+
+    await useAppStore.getState().bootstrap();
+
+    expect(useAppStore.getState().recentDocuments).toEqual(["notes/b.md"]);
   });
 
   it("ignores stale document reads when a newer selection finishes first", async () => {
@@ -188,4 +210,38 @@ describe("recent document helpers", () => {
       "b.md",
     ]);
   });
+
+  it("persists recent paths per root without storing content", () => {
+    const localStorage = installLocalStorageMock();
+
+    writeStoredRecentDocuments("/vault", ["a.md", "b.md"]);
+
+    expect(localStorage.getItem(`${RECENT_DOCUMENTS_STORAGE_KEY_PREFIX}:/vault`)).toBe(JSON.stringify(["a.md", "b.md"]));
+    expect(readStoredRecentDocuments("/vault")).toEqual(["a.md", "b.md"]);
+  });
+
+  it("removes persisted recents when the list is empty", () => {
+    const localStorage = installLocalStorageMock();
+    localStorage.setItem(recentDocumentsStorageKey("/vault"), JSON.stringify(["a.md"]));
+
+    writeStoredRecentDocuments("/vault", []);
+
+    expect(localStorage.getItem(recentDocumentsStorageKey("/vault"))).toBeNull();
+  });
 });
+
+function installLocalStorageMock() {
+  const values = new Map<string, string>();
+  const localStorage = {
+    getItem: (key: string) => values.get(key) ?? null,
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+
+  Object.defineProperty(globalThis, "window", {
+    value: { localStorage },
+    configurable: true,
+  });
+
+  return localStorage;
+}

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -13,6 +13,7 @@ interface AppStore {
   rootDir: string | null;
   files: string[];
   fileSet: ReadonlySet<string>;
+  recentDocuments: string[];
   scanState: ScanStatus;
   scanSkippedPaths: string[];
   scanSkippedPathSet: ReadonlySet<string>;
@@ -40,6 +41,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   rootDir: null,
   files: [],
   fileSet: new Set(),
+  recentDocuments: [],
   scanState: "idle",
   scanSkippedPaths: [],
   scanSkippedPathSet: new Set(),
@@ -100,6 +102,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         rootDir: session.rootDir,
         files,
         fileSet,
+        recentDocuments: pruneDocumentList(get().recentDocuments, fileSet),
         selectedFile: session.selectedFile,
       });
 
@@ -129,6 +132,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
       set({
         selectedFile: document.relativePath,
+        recentDocuments: addRecentDocument(get().recentDocuments, document.relativePath, get().fileSet),
         document: createReadyDocument(document.content, document.headings),
       });
     } catch (error) {
@@ -182,6 +186,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         rootDir: session.rootDir,
         files,
         fileSet,
+        recentDocuments: pruneDocumentList(previousState.recentDocuments, fileSet),
         selectedFile,
         scanState: "completed",
       });
@@ -258,4 +263,16 @@ function mergeSortedUnique(current: string[], currentSet: ReadonlySet<string>, i
   }
 
   return { values: [...next].sort(), valueSet: next };
+}
+
+export function addRecentDocument(current: string[], documentPath: string, availableFiles: ReadonlySet<string>, limit = 5) {
+  if (!availableFiles.has(documentPath)) {
+    return current;
+  }
+
+  return [documentPath, ...current.filter((path) => path !== documentPath && availableFiles.has(path))].slice(0, limit);
+}
+
+export function pruneDocumentList(paths: string[], availableFiles: ReadonlySet<string>, limit = 5) {
+  return paths.filter((path, index) => index === paths.indexOf(path) && availableFiles.has(path)).slice(0, limit);
 }

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -4,6 +4,8 @@ import { extractHeadings } from "@/lib/markdown";
 import { getInitialSession, readMarkdownFile, refreshSession, type ScanProgressPayload } from "@/lib/tauri";
 import type { HeadingItem, ScanStatus } from "@/types/content";
 
+export const RECENT_DOCUMENTS_STORAGE_KEY_PREFIX = "markmini.recentDocuments";
+
 type BootstrapState = "idle" | "loading" | "ready" | "error";
 type DocumentState = "idle" | "loading" | "ready" | "error";
 
@@ -97,12 +99,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       const session = await getInitialSession();
       const { values: files, valueSet: fileSet } = mergeSortedUnique([], new Set(), session.files);
+      const recentDocuments = pruneDocumentList(readStoredRecentDocuments(session.rootDir), fileSet);
       set({
         bootstrapState: "ready",
         rootDir: session.rootDir,
         files,
         fileSet,
-        recentDocuments: pruneDocumentList(get().recentDocuments, fileSet),
+        recentDocuments,
         selectedFile: session.selectedFile,
       });
 
@@ -130,9 +133,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
         return;
       }
 
+      const recentDocuments = addRecentDocument(get().recentDocuments, document.relativePath, get().fileSet);
+      writeStoredRecentDocuments(get().rootDir, recentDocuments);
+
       set({
         selectedFile: document.relativePath,
-        recentDocuments: addRecentDocument(get().recentDocuments, document.relativePath, get().fileSet),
+        recentDocuments,
         document: createReadyDocument(document.content, document.headings),
       });
     } catch (error) {
@@ -182,11 +188,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
       const session = await refreshSession();
       const { values: files, valueSet: fileSet } = mergeSortedUnique([], new Set(), session.files);
       const selectedFile = session.selectedFile;
+      const recentDocuments = pruneDocumentList(previousState.recentDocuments, fileSet);
+      writeStoredRecentDocuments(session.rootDir, recentDocuments);
       set({
         rootDir: session.rootDir,
         files,
         fileSet,
-        recentDocuments: pruneDocumentList(previousState.recentDocuments, fileSet),
+        recentDocuments,
         selectedFile,
         scanState: "completed",
       });
@@ -275,4 +283,38 @@ export function addRecentDocument(current: string[], documentPath: string, avail
 
 export function pruneDocumentList(paths: string[], availableFiles: ReadonlySet<string>, limit = 5) {
   return paths.filter((path, index) => index === paths.indexOf(path) && availableFiles.has(path)).slice(0, limit);
+}
+
+export function readStoredRecentDocuments(rootDir: string | null) {
+  if (!rootDir || typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(recentDocumentsStorageKey(rootDir)) ?? "[]");
+    return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeStoredRecentDocuments(rootDir: string | null, recentDocuments: string[]) {
+  if (!rootDir || typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    const key = recentDocumentsStorageKey(rootDir);
+    if (recentDocuments.length > 0) {
+      window.localStorage.setItem(key, JSON.stringify(recentDocuments));
+    } else {
+      window.localStorage.removeItem(key);
+    }
+  } catch {
+    // Ignore storage failures; recents still work for the current window state.
+  }
+}
+
+export function recentDocumentsStorageKey(rootDir: string) {
+  return `${RECENT_DOCUMENTS_STORAGE_KEY_PREFIX}:${rootDir}`;
 }


### PR DESCRIPTION
## Summary
- persist recent document relative paths per root in local storage
- restore and prune persisted recents during bootstrap
- prune and update persisted recents after refresh
- keep storage limited to relative paths, never document content
- add persistence helper/store tests

## Validation
- pnpm test
- pnpm typecheck
- pnpm build

Stacked after #116.
Closes #63