### PR TITLE
feat: add favorite documents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ function App() {
   const rootDir = useAppStore((state) => state.rootDir);
   const files = useAppStore((state) => state.files);
   const recentDocuments = useAppStore((state) => state.recentDocuments);
+  const favoriteDocuments = useAppStore((state) => state.favoriteDocuments);
   const scanState = useAppStore((state) => state.scanState);
   const scanSkippedPaths = useAppStore((state) => state.scanSkippedPaths);
   const scanError = useAppStore((state) => state.scanError);
@@ -26,6 +27,7 @@ function App() {
   const document = useAppStore((state) => state.document);
   const isSidebarOpen = useAppStore((state) => state.isSidebarOpen);
   const setSidebarOpen = useAppStore((state) => state.setSidebarOpen);
+  const toggleFavoriteDocument = useAppStore((state) => state.toggleFavoriteDocument);
 
   useEffect(() => {
     void bootstrap();
@@ -81,6 +83,7 @@ function App() {
                     <FileTree
                       files={files}
                       recentDocuments={recentDocuments}
+                      favoriteDocuments={favoriteDocuments}
                       scanState={scanState}
                       skippedCount={scanSkippedPaths.length}
                       selectedFile={selectedFile}
@@ -88,6 +91,7 @@ function App() {
                         void openDocument(file);
                         setSidebarOpen(false);
                       }}
+                      onToggleFavorite={toggleFavoriteDocument}
                     />
                   </div>
                 </SheetContent>
@@ -112,10 +116,12 @@ function App() {
                 <FileTree
                   files={files}
                   recentDocuments={recentDocuments}
+                  favoriteDocuments={favoriteDocuments}
                   scanState={scanState}
                   skippedCount={scanSkippedPaths.length}
                   selectedFile={selectedFile}
                   onSelect={(file) => void openDocument(file)}
+                  onToggleFavorite={toggleFavoriteDocument}
                 />
               </div>
             </aside>

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -1,5 +1,5 @@
 import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, ChevronRight, FileText, Folder, FolderOpen, Search } from "lucide-react";
+import { ChevronDown, ChevronRight, FileText, Folder, FolderOpen, Search, Star } from "lucide-react";
 
 import { fileLabel } from "@/lib/path";
 import { cn } from "@/lib/utils";
@@ -10,13 +10,24 @@ import type { ScanStatus } from "@/types/content";
 interface FileTreeProps {
   files: string[];
   recentDocuments: string[];
+  favoriteDocuments: string[];
   scanState: ScanStatus;
   skippedCount: number;
   selectedFile: string | null;
   onSelect: (relativePath: string) => void;
+  onToggleFavorite: (relativePath: string) => void;
 }
 
-export function FileTree({ files, recentDocuments, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
+export function FileTree({
+  files,
+  recentDocuments,
+  favoriteDocuments,
+  scanState,
+  skippedCount,
+  selectedFile,
+  onSelect,
+  onToggleFavorite,
+}: FileTreeProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredFiles = useMemo(() => filterFiles(files, normalizedSearchQuery), [files, normalizedSearchQuery]);
@@ -185,6 +196,29 @@ export function FileTree({ files, recentDocuments, scanState, skippedCount, sele
       <CardContent className="min-h-0 flex-1 p-0">
         <ScrollArea className="h-full">
           <div className="px-2 py-3">
+            {favoriteDocuments.length > 0 ? (
+              <div className="mb-3 border-b border-border/60 pb-3">
+                <p className="px-2 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">Favorites</p>
+                <div className="mt-2 space-y-0.5">
+                  {favoriteDocuments.map((path) => (
+                    <button
+                      key={path}
+                      type="button"
+                      className={cn(
+                        "flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+                        selectedFile === path
+                          ? "bg-primary text-primary-foreground shadow-sm"
+                          : "text-foreground hover:bg-accent hover:text-accent-foreground",
+                      )}
+                      onClick={() => onSelect(path)}
+                    >
+                      <Star className="h-4 w-4 shrink-0 fill-current text-yellow-500" />
+                      <span className="truncate">{fileLabel(path)}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
             {recentDocuments.length > 0 ? (
               <div className="mb-3 border-b border-border/60 pb-3">
                 <p className="px-2 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">Recent</p>
@@ -234,11 +268,13 @@ export function FileTree({ files, recentDocuments, scanState, skippedCount, sele
                     node={node}
                     selectedFile={selectedFile}
                     onSelect={onSelect}
+                    favorite={favoriteDocuments.includes(node.path)}
                     depth={depth}
                     expanded={expandedPaths.has(node.path)}
                     focused={currentFocusPath === node.path}
                     onFocusItem={setFocusedPath}
                     onToggle={toggleDirectory}
+                    onToggleFavorite={onToggleFavorite}
                   />
                 ))}
               </ul>
@@ -261,20 +297,24 @@ function TreeNode({
   node,
   selectedFile,
   onSelect,
+  favorite,
   depth,
   expanded,
   focused,
   onFocusItem,
   onToggle,
+  onToggleFavorite,
 }: {
   node: TreeNodeData;
   selectedFile: string | null;
   onSelect: (relativePath: string) => void;
+  favorite: boolean;
   depth: number;
   expanded: boolean;
   focused: boolean;
   onFocusItem: (path: string) => void;
   onToggle: (path: string) => void;
+  onToggleFavorite: (path: string) => void;
 }) {
   const isDirectory = node.kind === "directory";
   const isSelected = selectedFile === node.path;
@@ -315,26 +355,41 @@ function TreeNode({
 
   return (
     <li role="none">
-      <button
-        type="button"
+      <div
         role="treeitem"
         aria-selected={isSelected}
         aria-level={depth + 1}
-        tabIndex={focused ? 0 : -1}
         data-tree-path={node.path}
-        onFocus={() => onFocusItem(node.path)}
-        onClick={() => onSelect(node.path)}
         style={{ paddingLeft: treeNodeIndent(depth) }}
         className={cn(
-          "group flex h-9 w-full items-center gap-2 rounded-md pr-2 text-left text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+          "group flex h-9 w-full items-center gap-1 rounded-md pr-2 text-sm outline-none transition-colors focus-within:ring-2 focus-within:ring-ring",
           isSelected
             ? "bg-primary text-primary-foreground shadow-sm"
             : "text-foreground hover:bg-accent hover:text-accent-foreground",
         )}
       >
-        <FileText className={cn("h-4 w-4 shrink-0", isSelected ? "opacity-90" : "text-muted-foreground")} />
-        <span className="truncate">{label}</span>
-      </button>
+        <button
+          type="button"
+          tabIndex={focused ? 0 : -1}
+          onFocus={() => onFocusItem(node.path)}
+          onClick={() => onSelect(node.path)}
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-md text-left outline-none"
+        >
+          <FileText className={cn("h-4 w-4 shrink-0", isSelected ? "opacity-90" : "text-muted-foreground")} />
+          <span className="truncate">{label}</span>
+        </button>
+        <button
+          type="button"
+          aria-label={favorite ? `${label} 즐겨찾기 해제` : `${label} 즐겨찾기 추가`}
+          className={cn(
+            "flex h-7 w-7 shrink-0 items-center justify-center rounded-md opacity-70 outline-none transition hover:bg-background/50 hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring",
+            favorite ? "text-yellow-500 opacity-100" : isSelected ? "text-primary-foreground" : "text-muted-foreground",
+          )}
+          onClick={() => onToggleFavorite(node.path)}
+        >
+          <Star className={cn("h-4 w-4", favorite ? "fill-current" : "")} />
+        </button>
+      </div>
     </li>
   );
 }

--- a/src/store/app-store.test.ts
+++ b/src/store/app-store.test.ts
@@ -3,12 +3,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getInitialSession, readMarkdownFile, refreshSession } from "@/lib/tauri";
 import {
   RECENT_DOCUMENTS_STORAGE_KEY_PREFIX,
+  FAVORITE_DOCUMENTS_STORAGE_KEY_PREFIX,
   addRecentDocument,
+  favoriteDocumentsStorageKey,
   pruneDocumentList,
   readStoredRecentDocuments,
+  readStoredFavoriteDocuments,
   recentDocumentsStorageKey,
+  toggleDocumentPath,
   useAppStore,
   writeStoredRecentDocuments,
+  writeStoredFavoriteDocuments,
 } from "@/store/app-store";
 import type { HeadingItem, MarkdownDocument } from "@/types/content";
 
@@ -47,6 +52,7 @@ function resetStore() {
     files: [],
     fileSet: new Set(),
     recentDocuments: [],
+    favoriteDocuments: [],
     scanState: "idle",
     scanSkippedPaths: [],
     scanSkippedPathSet: new Set(),
@@ -108,6 +114,35 @@ describe("viewer app store", () => {
     await useAppStore.getState().bootstrap();
 
     expect(useAppStore.getState().recentDocuments).toEqual(["notes/b.md"]);
+  });
+
+  it("restores persisted favorite documents during bootstrap", async () => {
+    const localStorage = installLocalStorageMock();
+    localStorage.setItem(favoriteDocumentsStorageKey("/vault"), JSON.stringify(["notes/b.md", "missing.md"]));
+    vi.mocked(getInitialSession).mockResolvedValue({
+      rootDir: "/vault",
+      files: ["notes/a.md", "notes/b.md"],
+      selectedFile: null,
+    });
+
+    await useAppStore.getState().bootstrap();
+
+    expect(useAppStore.getState().favoriteDocuments).toEqual(["notes/b.md"]);
+  });
+
+  it("toggles favorite documents and persists relative paths", () => {
+    const localStorage = installLocalStorageMock();
+    useAppStore.setState({ rootDir: "/vault", files: ["notes/a.md"], fileSet: new Set(["notes/a.md"]) });
+
+    useAppStore.getState().toggleFavoriteDocument("notes/a.md");
+
+    expect(useAppStore.getState().favoriteDocuments).toEqual(["notes/a.md"]);
+    expect(localStorage.getItem(favoriteDocumentsStorageKey("/vault"))).toBe(JSON.stringify(["notes/a.md"]));
+
+    useAppStore.getState().toggleFavoriteDocument("notes/a.md");
+
+    expect(useAppStore.getState().favoriteDocuments).toEqual([]);
+    expect(localStorage.getItem(favoriteDocumentsStorageKey("/vault"))).toBeNull();
   });
 
   it("ignores stale document reads when a newer selection finishes first", async () => {
@@ -211,6 +246,12 @@ describe("recent document helpers", () => {
     ]);
   });
 
+  it("toggles available document paths without duplicates", () => {
+    expect(toggleDocumentPath(["b.md"], "a.md", new Set(["a.md", "b.md"]))).toEqual(["a.md", "b.md"]);
+    expect(toggleDocumentPath(["a.md", "b.md"], "a.md", new Set(["a.md", "b.md"]))).toEqual(["b.md"]);
+    expect(toggleDocumentPath(["a.md"], "missing.md", new Set(["a.md"]))).toEqual(["a.md"]);
+  });
+
   it("persists recent paths per root without storing content", () => {
     const localStorage = installLocalStorageMock();
 
@@ -227,6 +268,15 @@ describe("recent document helpers", () => {
     writeStoredRecentDocuments("/vault", []);
 
     expect(localStorage.getItem(recentDocumentsStorageKey("/vault"))).toBeNull();
+  });
+
+  it("persists favorite paths per root without storing content", () => {
+    const localStorage = installLocalStorageMock();
+
+    writeStoredFavoriteDocuments("/vault", ["a.md"]);
+
+    expect(localStorage.getItem(`${FAVORITE_DOCUMENTS_STORAGE_KEY_PREFIX}:/vault`)).toBe(JSON.stringify(["a.md"]));
+    expect(readStoredFavoriteDocuments("/vault")).toEqual(["a.md"]);
   });
 });
 

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -5,6 +5,7 @@ import { getInitialSession, readMarkdownFile, refreshSession, type ScanProgressP
 import type { HeadingItem, ScanStatus } from "@/types/content";
 
 export const RECENT_DOCUMENTS_STORAGE_KEY_PREFIX = "markmini.recentDocuments";
+export const FAVORITE_DOCUMENTS_STORAGE_KEY_PREFIX = "markmini.favoriteDocuments";
 
 type BootstrapState = "idle" | "loading" | "ready" | "error";
 type DocumentState = "idle" | "loading" | "ready" | "error";
@@ -16,6 +17,7 @@ interface AppStore {
   files: string[];
   fileSet: ReadonlySet<string>;
   recentDocuments: string[];
+  favoriteDocuments: string[];
   scanState: ScanStatus;
   scanSkippedPaths: string[];
   scanSkippedPathSet: ReadonlySet<string>;
@@ -30,6 +32,7 @@ interface AppStore {
     error: string | null;
   };
   setSidebarOpen: (open: boolean) => void;
+  toggleFavoriteDocument: (relativePath: string) => void;
   applyScanProgress: (payload: ScanProgressPayload) => Promise<void>;
   bootstrap: () => Promise<void>;
   openDocument: (relativePath: string) => Promise<void>;
@@ -44,6 +47,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   files: [],
   fileSet: new Set(),
   recentDocuments: [],
+  favoriteDocuments: [],
   scanState: "idle",
   scanSkippedPaths: [],
   scanSkippedPathSet: new Set(),
@@ -53,6 +57,16 @@ export const useAppStore = create<AppStore>((set, get) => ({
   isSidebarOpen: false,
   document: createEmptyDocument(),
   setSidebarOpen: (open) => set({ isSidebarOpen: open }),
+  toggleFavoriteDocument: (relativePath) => {
+    const state = get();
+    if (!state.fileSet.has(relativePath)) {
+      return;
+    }
+
+    const favoriteDocuments = toggleDocumentPath(state.favoriteDocuments, relativePath, state.fileSet, 50);
+    writeStoredFavoriteDocuments(state.rootDir, favoriteDocuments);
+    set({ favoriteDocuments });
+  },
   applyScanProgress: async (payload) => {
     const state = get();
     const { values: files, valueSet: fileSet } = mergeSortedUnique(
@@ -100,12 +114,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
       const session = await getInitialSession();
       const { values: files, valueSet: fileSet } = mergeSortedUnique([], new Set(), session.files);
       const recentDocuments = pruneDocumentList(readStoredRecentDocuments(session.rootDir), fileSet);
+      const favoriteDocuments = pruneDocumentList(readStoredFavoriteDocuments(session.rootDir), fileSet, 50);
       set({
         bootstrapState: "ready",
         rootDir: session.rootDir,
         files,
         fileSet,
         recentDocuments,
+        favoriteDocuments,
         selectedFile: session.selectedFile,
       });
 
@@ -189,12 +205,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
       const { values: files, valueSet: fileSet } = mergeSortedUnique([], new Set(), session.files);
       const selectedFile = session.selectedFile;
       const recentDocuments = pruneDocumentList(previousState.recentDocuments, fileSet);
+      const favoriteDocuments = pruneDocumentList(previousState.favoriteDocuments, fileSet, 50);
       writeStoredRecentDocuments(session.rootDir, recentDocuments);
+      writeStoredFavoriteDocuments(session.rootDir, favoriteDocuments);
       set({
         rootDir: session.rootDir,
         files,
         fileSet,
         recentDocuments,
+        favoriteDocuments,
         selectedFile,
         scanState: "completed",
       });
@@ -285,28 +304,64 @@ export function pruneDocumentList(paths: string[], availableFiles: ReadonlySet<s
   return paths.filter((path, index) => index === paths.indexOf(path) && availableFiles.has(path)).slice(0, limit);
 }
 
+export function toggleDocumentPath(current: string[], documentPath: string, availableFiles: ReadonlySet<string>, limit = 50) {
+  if (!availableFiles.has(documentPath)) {
+    return current;
+  }
+
+  if (current.includes(documentPath)) {
+    return current.filter((path) => path !== documentPath);
+  }
+
+  return pruneDocumentList([documentPath, ...current], availableFiles, limit);
+}
+
 export function readStoredRecentDocuments(rootDir: string | null) {
+  return readStoredDocumentList(rootDir, RECENT_DOCUMENTS_STORAGE_KEY_PREFIX);
+}
+
+export function writeStoredRecentDocuments(rootDir: string | null, recentDocuments: string[]) {
+  writeStoredDocumentList(rootDir, RECENT_DOCUMENTS_STORAGE_KEY_PREFIX, recentDocuments);
+}
+
+export function readStoredFavoriteDocuments(rootDir: string | null) {
+  return readStoredDocumentList(rootDir, FAVORITE_DOCUMENTS_STORAGE_KEY_PREFIX);
+}
+
+export function writeStoredFavoriteDocuments(rootDir: string | null, favoriteDocuments: string[]) {
+  writeStoredDocumentList(rootDir, FAVORITE_DOCUMENTS_STORAGE_KEY_PREFIX, favoriteDocuments);
+}
+
+export function recentDocumentsStorageKey(rootDir: string) {
+  return documentListStorageKey(RECENT_DOCUMENTS_STORAGE_KEY_PREFIX, rootDir);
+}
+
+export function favoriteDocumentsStorageKey(rootDir: string) {
+  return documentListStorageKey(FAVORITE_DOCUMENTS_STORAGE_KEY_PREFIX, rootDir);
+}
+
+function readStoredDocumentList(rootDir: string | null, keyPrefix: string) {
   if (!rootDir || typeof window === "undefined") {
     return [];
   }
 
   try {
-    const parsed = JSON.parse(window.localStorage.getItem(recentDocumentsStorageKey(rootDir)) ?? "[]");
+    const parsed = JSON.parse(window.localStorage.getItem(documentListStorageKey(keyPrefix, rootDir)) ?? "[]");
     return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === "string") : [];
   } catch {
     return [];
   }
 }
 
-export function writeStoredRecentDocuments(rootDir: string | null, recentDocuments: string[]) {
+function writeStoredDocumentList(rootDir: string | null, keyPrefix: string, paths: string[]) {
   if (!rootDir || typeof window === "undefined") {
     return;
   }
 
   try {
-    const key = recentDocumentsStorageKey(rootDir);
-    if (recentDocuments.length > 0) {
-      window.localStorage.setItem(key, JSON.stringify(recentDocuments));
+    const key = documentListStorageKey(keyPrefix, rootDir);
+    if (paths.length > 0) {
+      window.localStorage.setItem(key, JSON.stringify(paths));
     } else {
       window.localStorage.removeItem(key);
     }
@@ -315,6 +370,6 @@ export function writeStoredRecentDocuments(rootDir: string | null, recentDocumen
   }
 }
 
-export function recentDocumentsStorageKey(rootDir: string) {
-  return `${RECENT_DOCUMENTS_STORAGE_KEY_PREFIX}:${rootDir}`;
+function documentListStorageKey(keyPrefix: string, rootDir: string) {
+  return `${keyPrefix}:${rootDir}`;
 }


### PR DESCRIPTION
## Summary
- add persistent favorite document state per root
- expose favorite toggles from document tree file rows
- show a Favorites section above Recent
- prune stale favorites when the root file list changes
- store only relative paths, never document content
- add store/helper tests for favorite restore, toggle, pruning, and persistence

## Validation
- pnpm test
- pnpm typecheck
- pnpm build

Stacked after #116 and #117.
Closes #65