### PR TITLE
feat: add document tree sort controls

### DIFF
--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import { buildTree, filterFiles, flattenVisibleTree, treeNodeIndent } from "./file-tree";
+import {
+  DOCUMENT_TREE_SORT_MODE_STORAGE_KEY,
+  buildTree,
+  filterFiles,
+  flattenVisibleTree,
+  parseSortMode,
+  readStoredSortMode,
+  treeNodeIndent,
+  writeStoredSortMode,
+} from "./file-tree";
 
 const files = ["docs/guide.md", "notes/today.md", "projects/markmini/plan.md"];
 
@@ -114,3 +123,35 @@ describe("file tree structure", () => {
     expect([0, 1, 2, 3].map(treeNodeIndent)).toEqual(["8px", "28px", "48px", "68px"]);
   });
 });
+
+describe("document tree sorting", () => {
+  it("parses unknown sort modes as name sort", () => {
+    expect(parseSortMode("path")).toBe("path");
+    expect(parseSortMode("modified")).toBe("name");
+    expect(parseSortMode(null)).toBe("name");
+  });
+
+  it("stores and restores the selected sort mode in session storage", () => {
+    const sessionStorage = installSessionStorageMock();
+
+    writeStoredSortMode("path");
+
+    expect(sessionStorage.getItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY)).toBe("path");
+    expect(readStoredSortMode()).toBe("path");
+  });
+});
+
+function installSessionStorageMock() {
+  const values = new Map<string, string>();
+  const sessionStorage = {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+
+  Object.defineProperty(globalThis, "window", {
+    value: { sessionStorage },
+    configurable: true,
+  });
+
+  return sessionStorage;
+}

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -7,6 +7,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type { ScanStatus } from "@/types/content";
 
+export type DocumentTreeSortMode = "name" | "path";
+
+export const DOCUMENT_TREE_SORT_MODE_STORAGE_KEY = "markmini.documentTree.sortMode";
+
 interface FileTreeProps {
   files: string[];
   scanState: ScanStatus;
@@ -17,15 +21,20 @@ interface FileTreeProps {
 
 export function FileTree({ files, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
   const [searchQuery, setSearchQuery] = useState("");
+  const [sortMode, setSortMode] = useState<DocumentTreeSortMode>(readStoredSortMode);
   const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredFiles = useMemo(() => filterFiles(files, normalizedSearchQuery), [files, normalizedSearchQuery]);
-  const tree = useMemo(() => buildTree(filteredFiles), [filteredFiles]);
+  const tree = useMemo(() => buildTree(filteredFiles, sortMode), [filteredFiles, sortMode]);
   const directoryPaths = useMemo(() => collectDirectoryPaths(tree), [tree]);
   const selectedFileIsFilteredOut = Boolean(normalizedSearchQuery && selectedFile && !filteredFiles.includes(selectedFile));
   const hasInitializedExpansionRef = useRef(false);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set());
   const [focusedPath, setFocusedPath] = useState<string | null>(selectedFile);
   const treeRef = useRef<HTMLUListElement | null>(null);
+
+  useEffect(() => {
+    writeStoredSortMode(sortMode);
+  }, [sortMode]);
 
   useEffect(() => {
     setExpandedPaths((current) => {
@@ -173,6 +182,18 @@ export function FileTree({ files, scanState, skippedCount, selectedFile, onSelec
             aria-label="문서 검색"
             className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm text-foreground outline-none transition placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           />
+        </div>
+        <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+          <span>정렬</span>
+          <select
+            value={sortMode}
+            onChange={(event) => setSortMode(parseSortMode(event.target.value))}
+            aria-label="문서 트리 정렬"
+            className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <option value="name">이름순</option>
+            <option value="path">경로순</option>
+          </select>
         </div>
         {scanState === "scanning" || skippedCount > 0 ? (
           <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
@@ -371,14 +392,42 @@ export function filterFiles(files: string[], normalizedSearchQuery: string) {
   });
 }
 
-export function buildTree(files: string[]) {
+export function readStoredSortMode(): DocumentTreeSortMode {
+  if (typeof window === "undefined") {
+    return "name";
+  }
+
+  try {
+    return parseSortMode(window.sessionStorage.getItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY));
+  } catch {
+    return "name";
+  }
+}
+
+export function writeStoredSortMode(sortMode: DocumentTreeSortMode) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY, sortMode);
+  } catch {
+    // Keep sorting usable even if session storage is unavailable.
+  }
+}
+
+export function parseSortMode(value: unknown): DocumentTreeSortMode {
+  return value === "path" ? "path" : "name";
+}
+
+export function buildTree(files: string[], sortMode: DocumentTreeSortMode = "name") {
   const root: TreeNodeData[] = [];
 
   for (const file of files) {
     insertNode(root, file.split("/"), "", file);
   }
 
-  return sortTree(root);
+  return sortTree(root, sortMode);
 }
 
 function insertNode(nodes: TreeNodeData[], segments: string[], parentPath: string, originalPath: string) {
@@ -411,17 +460,19 @@ function insertNode(nodes: TreeNodeData[], segments: string[], parentPath: strin
   }
 }
 
-function sortTree(nodes: TreeNodeData[]): TreeNodeData[] {
+function sortTree(nodes: TreeNodeData[], sortMode: DocumentTreeSortMode): TreeNodeData[] {
   return nodes
     .map((node) => ({
       ...node,
-      children: sortTree(node.children),
+      children: sortTree(node.children, sortMode),
     }))
     .sort((left, right) => {
       if (left.kind !== right.kind) {
         return left.kind === "directory" ? -1 : 1;
       }
 
-      return left.name.localeCompare(right.name);
+      const leftValue = sortMode === "path" ? left.path : left.name;
+      const rightValue = sortMode === "path" ? right.path : right.name;
+      return leftValue.localeCompare(rightValue);
     });
 }


### PR DESCRIPTION
## Summary
- add a compact document tree sort control next to search
- support name and path sort modes while preserving directory-first tree grouping
- persist the selected sort mode in per-window session storage
- add focused tests for sort mode parsing and storage

## Validation
- pnpm test
- pnpm typecheck
- pnpm build

Closes #67