### PR TITLE
feat: show modified time context

### DIFF
--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -5,6 +5,7 @@ import {
   buildTree,
   filterFiles,
   flattenVisibleTree,
+  formatModifiedAt,
   parseSortMode,
   readStoredSortMode,
   treeNodeIndent,
@@ -154,6 +155,18 @@ describe("document tree sorting", () => {
 
     expect(tree.map((node) => node.path)).toEqual(["notes", "docs", "old.md"]);
     expect(tree[1]?.children.map((node) => node.path)).toEqual(["docs/newer.md", "docs/older.md"]);
+  });
+});
+
+describe("modified time labels", () => {
+  it("formats recent modified times without exposing file content", () => {
+    const now = Date.UTC(2026, 3, 28, 13, 0, 0);
+
+    expect(formatModifiedAt(null, now)).toBeNull();
+    expect(formatModifiedAt(now - 30_000, now)).toBe("방금 전");
+    expect(formatModifiedAt(now - 5 * 60_000, now)).toBe("5분 전");
+    expect(formatModifiedAt(now - 3 * 60 * 60_000, now)).toBe("3시간 전");
+    expect(formatModifiedAt(now - 2 * 24 * 60 * 60_000, now)).toBe("2일 전");
   });
 });
 

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -234,6 +234,8 @@ export function FileTree({ files, fileMetadata, scanState, skippedCount, selecte
                     node={node}
                     selectedFile={selectedFile}
                     onSelect={onSelect}
+                    fileMetadata={fileMetadata}
+                    sortMode={sortMode}
                     depth={depth}
                     expanded={expandedPaths.has(node.path)}
                     focused={currentFocusPath === node.path}
@@ -261,6 +263,8 @@ function TreeNode({
   node,
   selectedFile,
   onSelect,
+  fileMetadata,
+  sortMode,
   depth,
   expanded,
   focused,
@@ -270,6 +274,8 @@ function TreeNode({
   node: TreeNodeData;
   selectedFile: string | null;
   onSelect: (relativePath: string) => void;
+  fileMetadata: Record<string, MarkdownFileMetadata>;
+  sortMode: DocumentTreeSortMode;
   depth: number;
   expanded: boolean;
   focused: boolean;
@@ -279,6 +285,8 @@ function TreeNode({
   const isDirectory = node.kind === "directory";
   const isSelected = selectedFile === node.path;
   const label = isDirectory ? node.name : fileLabel(node.path);
+  const modifiedLabel =
+    sortMode === "modified" && node.kind === "file" ? formatModifiedAt(fileMetadata[node.path]?.modifiedAt) : null;
 
   if (node.kind === "directory") {
     return (
@@ -333,7 +341,12 @@ function TreeNode({
         )}
       >
         <FileText className={cn("h-4 w-4 shrink-0", isSelected ? "opacity-90" : "text-muted-foreground")} />
-        <span className="truncate">{label}</span>
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        {modifiedLabel ? (
+          <span className={cn("ml-auto shrink-0 text-[11px] tabular-nums", isSelected ? "opacity-80" : "text-muted-foreground")}>
+            {modifiedLabel}
+          </span>
+        ) : null}
       </button>
     </li>
   );
@@ -501,4 +514,36 @@ function modifiedAt(node: TreeNodeData, fileMetadata: Record<string, MarkdownFil
   }
 
   return Math.max(0, ...node.children.map((child) => modifiedAt(child, fileMetadata)));
+}
+
+export function formatModifiedAt(modifiedAt: number | null | undefined, now = Date.now()): string | null {
+  if (!modifiedAt) {
+    return null;
+  }
+
+  const diffMs = Math.max(0, now - modifiedAt);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (diffMs < minute) {
+    return "방금 전";
+  }
+
+  if (diffMs < hour) {
+    return `${Math.floor(diffMs / minute)}분 전`;
+  }
+
+  if (diffMs < day) {
+    return `${Math.floor(diffMs / hour)}시간 전`;
+  }
+
+  if (diffMs < 7 * day) {
+    return `${Math.floor(diffMs / day)}일 전`;
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(modifiedAt));
 }


### PR DESCRIPTION
## Summary
- show lightweight modified-time labels for file rows when the tree is sorted by modified time
- keep the default name/path modes uncluttered
- handle missing metadata gracefully
- add focused tests for modified-time label formatting

## Validation
- pnpm test
- pnpm typecheck
- pnpm build
- cargo test --manifest-path src-tauri/Cargo.toml

Stacked after #120.
Closes #71