### PR TITLE
feat: persist document tree sort preference

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ function App() {
                   </SheetHeader>
                   <div className="h-[calc(100vh-72px)] overflow-hidden">
                     <FileTree
+                      rootDir={rootDir}
                       files={files}
                       fileMetadata={fileMetadata}
                       scanState={scanState}
@@ -110,6 +111,7 @@ function App() {
             <aside className="hidden min-h-0 lg:block">
               <div className="sticky top-4 h-[calc(100vh-8rem)]">
                 <FileTree
+                  rootDir={rootDir}
                   files={files}
                   fileMetadata={fileMetadata}
                   scanState={scanState}

--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   DOCUMENT_TREE_SORT_MODE_STORAGE_KEY,
   buildTree,
+  documentTreeSortModeStorageKey,
   filterFiles,
   flattenVisibleTree,
   formatModifiedAt,
@@ -132,13 +133,16 @@ describe("document tree sorting", () => {
     expect(parseSortMode(null)).toBe("name");
   });
 
-  it("stores and restores the selected sort mode in session storage", () => {
-    const sessionStorage = installSessionStorageMock();
+  it("stores and restores the selected sort mode per root", () => {
+    const localStorage = installLocalStorageMock();
 
-    writeStoredSortMode("path");
+    writeStoredSortMode("/vault-a", "path");
+    writeStoredSortMode("/vault-b", "modified");
 
-    expect(sessionStorage.getItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY)).toBe("path");
-    expect(readStoredSortMode()).toBe("path");
+    expect(localStorage.getItem(documentTreeSortModeStorageKey("/vault-a"))).toBe("path");
+    expect(localStorage.getItem(`${DOCUMENT_TREE_SORT_MODE_STORAGE_KEY}:/vault-b`)).toBe("modified");
+    expect(readStoredSortMode("/vault-a")).toBe("path");
+    expect(readStoredSortMode("/vault-b")).toBe("modified");
   });
 
   it("sorts files and directories by newest modified time when metadata is available", () => {
@@ -170,17 +174,17 @@ describe("modified time labels", () => {
   });
 });
 
-function installSessionStorageMock() {
+function installLocalStorageMock() {
   const values = new Map<string, string>();
-  const sessionStorage = {
+  const localStorage = {
     getItem: (key: string) => values.get(key) ?? null,
     setItem: (key: string, value: string) => values.set(key, value),
   };
 
   Object.defineProperty(globalThis, "window", {
-    value: { sessionStorage },
+    value: { localStorage },
     configurable: true,
   });
 
-  return sessionStorage;
+  return localStorage;
 }

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -13,6 +13,7 @@ export type DocumentTreeSortMode = "name" | "path" | "modified";
 export const DOCUMENT_TREE_SORT_MODE_STORAGE_KEY = "markmini.documentTree.sortMode";
 
 interface FileTreeProps {
+  rootDir: string | null;
   files: string[];
   fileMetadata: Record<string, MarkdownFileMetadata>;
   scanState: ScanStatus;
@@ -21,9 +22,9 @@ interface FileTreeProps {
   onSelect: (relativePath: string) => void;
 }
 
-export function FileTree({ files, fileMetadata, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
+export function FileTree({ rootDir, files, fileMetadata, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [sortMode, setSortMode] = useState<DocumentTreeSortMode>(readStoredSortMode);
+  const [sortMode, setSortMode] = useState<DocumentTreeSortMode>(() => readStoredSortMode(rootDir));
   const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredFiles = useMemo(() => filterFiles(files, normalizedSearchQuery), [files, normalizedSearchQuery]);
   const tree = useMemo(() => buildTree(filteredFiles, sortMode, fileMetadata), [filteredFiles, fileMetadata, sortMode]);
@@ -35,8 +36,12 @@ export function FileTree({ files, fileMetadata, scanState, skippedCount, selecte
   const treeRef = useRef<HTMLUListElement | null>(null);
 
   useEffect(() => {
-    writeStoredSortMode(sortMode);
-  }, [sortMode]);
+    setSortMode(readStoredSortMode(rootDir));
+  }, [rootDir]);
+
+  useEffect(() => {
+    writeStoredSortMode(rootDir, sortMode);
+  }, [rootDir, sortMode]);
 
   useEffect(() => {
     setExpandedPaths((current) => {
@@ -408,27 +413,31 @@ export function filterFiles(files: string[], normalizedSearchQuery: string) {
   });
 }
 
-export function readStoredSortMode(): DocumentTreeSortMode {
+export function documentTreeSortModeStorageKey(rootDir: string | null) {
+  return rootDir ? `${DOCUMENT_TREE_SORT_MODE_STORAGE_KEY}:${rootDir}` : DOCUMENT_TREE_SORT_MODE_STORAGE_KEY;
+}
+
+export function readStoredSortMode(rootDir: string | null = null): DocumentTreeSortMode {
   if (typeof window === "undefined") {
     return "name";
   }
 
   try {
-    return parseSortMode(window.sessionStorage.getItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY));
+    return parseSortMode(window.localStorage.getItem(documentTreeSortModeStorageKey(rootDir)));
   } catch {
     return "name";
   }
 }
 
-export function writeStoredSortMode(sortMode: DocumentTreeSortMode) {
+export function writeStoredSortMode(rootDir: string | null, sortMode: DocumentTreeSortMode) {
   if (typeof window === "undefined") {
     return;
   }
 
   try {
-    window.sessionStorage.setItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY, sortMode);
+    window.localStorage.setItem(documentTreeSortModeStorageKey(rootDir), sortMode);
   } catch {
-    // Keep sorting usable even if session storage is unavailable.
+    // Keep sorting usable even if local storage is unavailable.
   }
 }
 


### PR DESCRIPTION
## Summary
- persist document tree sort mode in localStorage by root directory
- restore the root-specific preference when the opened root changes
- keep a safe default for windows without a resolved root yet
- add focused tests for per-root sort storage keys and restore behavior

## Validation
- pnpm test
- pnpm typecheck
- pnpm build
- cargo test --manifest-path src-tauri/Cargo.toml

Stacked after #121.
Closes #73