### PR TITLE
feat: show file size context

### DIFF
--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -6,6 +6,7 @@ import {
   documentTreeSortModeStorageKey,
   filterFiles,
   flattenVisibleTree,
+  formatFileSize,
   formatModifiedAt,
   parseSortMode,
   readStoredSortMode,
@@ -162,7 +163,7 @@ describe("document tree sorting", () => {
   });
 });
 
-describe("modified time labels", () => {
+describe("metadata labels", () => {
   it("formats recent modified times without exposing file content", () => {
     const now = Date.UTC(2026, 3, 28, 13, 0, 0);
 
@@ -171,6 +172,15 @@ describe("modified time labels", () => {
     expect(formatModifiedAt(now - 5 * 60_000, now)).toBe("5분 전");
     expect(formatModifiedAt(now - 3 * 60 * 60_000, now)).toBe("3시간 전");
     expect(formatModifiedAt(now - 2 * 24 * 60 * 60_000, now)).toBe("2일 전");
+  });
+
+  it("formats file sizes from content-free metadata", () => {
+    expect(formatFileSize(null)).toBeNull();
+    expect(formatFileSize(0)).toBe("0 B");
+    expect(formatFileSize(512)).toBe("512 B");
+    expect(formatFileSize(1536)).toBe("1.5 KB");
+    expect(formatFileSize(12 * 1024)).toBe("12 KB");
+    expect(formatFileSize(2.5 * 1024 * 1024)).toBe("2.5 MB");
   });
 });
 

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -292,6 +292,7 @@ function TreeNode({
   const label = isDirectory ? node.name : fileLabel(node.path);
   const modifiedLabel =
     sortMode === "modified" && node.kind === "file" ? formatModifiedAt(fileMetadata[node.path]?.modifiedAt) : null;
+  const sizeLabel = node.kind === "file" ? formatFileSize(fileMetadata[node.path]?.sizeBytes) : null;
 
   if (node.kind === "directory") {
     return (
@@ -347,9 +348,9 @@ function TreeNode({
       >
         <FileText className={cn("h-4 w-4 shrink-0", isSelected ? "opacity-90" : "text-muted-foreground")} />
         <span className="min-w-0 flex-1 truncate">{label}</span>
-        {modifiedLabel ? (
+        {modifiedLabel || sizeLabel ? (
           <span className={cn("ml-auto shrink-0 text-[11px] tabular-nums", isSelected ? "opacity-80" : "text-muted-foreground")}>
-            {modifiedLabel}
+            {modifiedLabel ?? sizeLabel}
           </span>
         ) : null}
       </button>
@@ -555,4 +556,25 @@ export function formatModifiedAt(modifiedAt: number | null | undefined, now = Da
     month: "short",
     day: "numeric",
   }).format(new Date(modifiedAt));
+}
+
+export function formatFileSize(sizeBytes: number | null | undefined): string | null {
+  if (sizeBytes == null) {
+    return null;
+  }
+
+  if (sizeBytes < 1024) {
+    return `${sizeBytes} B`;
+  }
+
+  const units = ["KB", "MB", "GB"];
+  let value = sizeBytes / 1024;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} ${units[unitIndex]}`;
 }


### PR DESCRIPTION
## Summary
- show lightweight file-size labels for document rows using metadata only
- keep modified-time labels prioritized in modified sort mode
- handle missing file size metadata gracefully
- add focused tests for file-size label formatting

## Validation
- pnpm test
- pnpm typecheck
- pnpm build
- cargo test --manifest-path src-tauri/Cargo.toml

Stacked after #124.
Closes #81