### PR TITLE
feat: add file size sort mode

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1181,6 +1181,90 @@ mod tests {
     }
 
     #[test]
+    fn metadata_for_files_preserves_file_order_and_prunes_stale_entries() {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "notes/a.md".to_string(),
+            MarkdownFileMetadata {
+                relative_path: "notes/a.md".to_string(),
+                modified_at: Some(10),
+            },
+        );
+        metadata.insert(
+            "notes/b.md".to_string(),
+            MarkdownFileMetadata {
+                relative_path: "notes/b.md".to_string(),
+                modified_at: Some(20),
+            },
+        );
+        metadata.insert(
+            "stale.md".to_string(),
+            MarkdownFileMetadata {
+                relative_path: "stale.md".to_string(),
+                modified_at: Some(30),
+            },
+        );
+
+        let files = vec!["notes/b.md".to_string(), "notes/a.md".to_string()];
+        let payload = metadata_for_files(&files, &metadata);
+
+        assert_eq!(
+            payload
+                .iter()
+                .map(|entry| entry.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["notes/b.md", "notes/a.md"]
+        );
+        assert_eq!(
+            payload
+                .iter()
+                .map(|entry| entry.modified_at)
+                .collect::<Vec<_>>(),
+            vec![Some(20), Some(10)]
+        );
+    }
+
+    #[test]
+    fn merge_metadata_replaces_existing_paths_without_reading_content() {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "notes/a.md".to_string(),
+            MarkdownFileMetadata {
+                relative_path: "notes/a.md".to_string(),
+                modified_at: Some(10),
+            },
+        );
+
+        merge_metadata(
+            &mut metadata,
+            &[
+                MarkdownFileMetadata {
+                    relative_path: "notes/a.md".to_string(),
+                    modified_at: Some(100),
+                },
+                MarkdownFileMetadata {
+                    relative_path: "notes/b.md".to_string(),
+                    modified_at: Some(200),
+                },
+            ],
+        );
+
+        assert_eq!(
+            metadata
+                .get("notes/a.md")
+                .and_then(|entry| entry.modified_at),
+            Some(100)
+        );
+        assert_eq!(
+            metadata
+                .get("notes/b.md")
+                .and_then(|entry| entry.modified_at),
+            Some(200)
+        );
+        assert_eq!(metadata.len(), 2);
+    }
+
+    #[test]
     fn pick_default_document_prefers_readme_then_first_file() {
         assert_eq!(
             pick_default_document(&["notes/a.md".to_string(), "README.md".to_string()]),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,7 +23,15 @@ use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 struct InitialSession {
     root_dir: String,
     files: Vec<String>,
+    file_metadata: Vec<MarkdownFileMetadata>,
     selected_file: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct MarkdownFileMetadata {
+    relative_path: String,
+    modified_at: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -47,6 +55,7 @@ struct SessionState {
     root_dir: PathBuf,
     canonical_root_dir: PathBuf,
     files: Vec<String>,
+    file_metadata: HashMap<String, MarkdownFileMetadata>,
     selected_file: Option<String>,
 }
 
@@ -57,7 +66,7 @@ struct AppState {
 }
 
 enum ScanEntry {
-    File(String),
+    File(MarkdownFileMetadata),
     Skipped(String),
 }
 
@@ -80,6 +89,7 @@ enum ScanStatus {
 #[serde(rename_all = "camelCase")]
 struct ScanProgressPayload {
     files: Vec<String>,
+    file_metadata: Vec<MarkdownFileMetadata>,
     selected_file: Option<String>,
     status: ScanStatus,
     skipped_paths: Vec<String>,
@@ -111,6 +121,7 @@ fn get_initial_session(
     Ok(InitialSession {
         root_dir: session.root_dir.to_string_lossy().to_string(),
         files: session.files.clone(),
+        file_metadata: metadata_for_files(&session.files, &session.file_metadata),
         selected_file: session.selected_file.clone(),
     })
 }
@@ -129,8 +140,17 @@ fn refresh_session(
         .get_mut(window.label())
         .ok_or_else(|| format!("no session for window {}", window.label()))?;
 
-    let mut files = collect_markdown_files(&session.root_dir, &session.canonical_root_dir)?;
-    files.sort();
+    let mut file_entries =
+        collect_markdown_file_entries(&session.root_dir, &session.canonical_root_dir)?;
+    file_entries.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    let files = file_entries
+        .iter()
+        .map(|metadata| metadata.relative_path.clone())
+        .collect::<Vec<_>>();
+    let file_metadata = file_entries
+        .into_iter()
+        .map(|metadata| (metadata.relative_path.clone(), metadata))
+        .collect::<HashMap<_, _>>();
 
     let selected_file = match &session.selected_file {
         Some(current) if files.iter().any(|entry| entry == current) => Some(current.clone()),
@@ -138,10 +158,12 @@ fn refresh_session(
     };
 
     session.files = files.clone();
+    session.file_metadata = file_metadata.clone();
     session.selected_file = selected_file.clone();
 
     Ok(InitialSession {
         root_dir: session.root_dir.to_string_lossy().to_string(),
+        file_metadata: metadata_for_files(&files, &file_metadata),
         files,
         selected_file,
     })
@@ -206,6 +228,7 @@ pub fn run() {
         root_dir: initial_root_dir.clone(),
         canonical_root_dir: initial_root_dir.clone(),
         files: Vec::new(),
+        file_metadata: HashMap::new(),
         selected_file: None,
     };
 
@@ -275,6 +298,7 @@ fn populate_session_async(
         SCAN_PROGRESS_EVENT,
         ScanProgressPayload {
             files: Vec::new(),
+            file_metadata: Vec::new(),
             selected_file: None,
             status: ScanStatus::Scanning,
             skipped_paths: Vec::new(),
@@ -283,14 +307,18 @@ fn populate_session_async(
     );
 
     let mut files = Vec::<String>::new();
+    let mut file_metadata = HashMap::<String, MarkdownFileMetadata>::new();
     let mut pending_files = Vec::<String>::new();
+    let mut pending_file_metadata = Vec::<MarkdownFileMetadata>::new();
     let mut skipped_paths = Vec::<String>::new();
     let mut pending_skipped_paths = Vec::<String>::new();
     let mut selected_file = None::<String>;
 
     let flush_progress = |app_handle: &tauri::AppHandle,
                           files: &mut Vec<String>,
+                          file_metadata: &mut HashMap<String, MarkdownFileMetadata>,
                           pending_files: &mut Vec<String>,
+                          pending_file_metadata: &mut Vec<MarkdownFileMetadata>,
                           pending_skipped_paths: &mut Vec<String>,
                           selected_file: &mut Option<String>| {
         if pending_files.is_empty() && pending_skipped_paths.is_empty() {
@@ -313,15 +341,19 @@ fn populate_session_async(
             let mut sessions = state.sessions.lock().expect("sessions lock poisoned");
             if let Some(session) = sessions.get_mut(label) {
                 merge_sorted_unique(&mut session.files, pending_files);
+                merge_metadata(&mut session.file_metadata, pending_file_metadata);
                 session.selected_file = selected_file.clone();
             }
         }
 
         merge_sorted_unique(files, pending_files);
+        merge_metadata(file_metadata, pending_file_metadata);
 
         let emitted_files = pending_files.clone();
+        let emitted_file_metadata = pending_file_metadata.clone();
         let emitted_skipped_paths = pending_skipped_paths.clone();
         pending_files.clear();
+        pending_file_metadata.clear();
         pending_skipped_paths.clear();
 
         let _ = app_handle.emit_to(
@@ -329,6 +361,7 @@ fn populate_session_async(
             SCAN_PROGRESS_EVENT,
             ScanProgressPayload {
                 files: emitted_files,
+                file_metadata: emitted_file_metadata,
                 selected_file: selected_file.clone(),
                 status: ScanStatus::Scanning,
                 skipped_paths: emitted_skipped_paths,
@@ -339,7 +372,10 @@ fn populate_session_async(
 
     let scan_result = visit_dir_streaming(&root_dir, &root_dir, &mut |entry| {
         match entry {
-            ScanEntry::File(relative) => pending_files.push(relative),
+            ScanEntry::File(metadata) => {
+                pending_files.push(metadata.relative_path.clone());
+                pending_file_metadata.push(metadata);
+            }
             ScanEntry::Skipped(skipped) => {
                 skipped_paths.push(skipped.clone());
                 pending_skipped_paths.push(skipped);
@@ -351,7 +387,9 @@ fn populate_session_async(
             flush_progress(
                 app_handle,
                 &mut files,
+                &mut file_metadata,
                 &mut pending_files,
+                &mut pending_file_metadata,
                 &mut pending_skipped_paths,
                 &mut selected_file,
             );
@@ -361,7 +399,9 @@ fn populate_session_async(
     flush_progress(
         app_handle,
         &mut files,
+        &mut file_metadata,
         &mut pending_files,
+        &mut pending_file_metadata,
         &mut pending_skipped_paths,
         &mut selected_file,
     );
@@ -391,6 +431,7 @@ fn populate_session_async(
         let mut sessions = state.sessions.lock().expect("sessions lock poisoned");
         if let Some(session) = sessions.get_mut(label) {
             session.files = files.clone();
+            session.file_metadata = file_metadata.clone();
             session.selected_file = selected_file.clone();
         }
     }
@@ -399,6 +440,7 @@ fn populate_session_async(
         label,
         SCAN_PROGRESS_EVENT,
         ScanProgressPayload {
+            file_metadata: metadata_for_files(&files, &file_metadata),
             files,
             selected_file,
             status: final_status,
@@ -457,6 +499,7 @@ fn handle_new_instance(app: &tauri::AppHandle, argv: Vec<String>, cwd: String) {
                 root_dir: root_dir.clone(),
                 canonical_root_dir: root_dir.clone(),
                 files: Vec::new(),
+                file_metadata: HashMap::new(),
                 selected_file: None,
             },
         );
@@ -744,10 +787,23 @@ fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
 // File scanning
 // ---------------------------------------------------------------------------
 
+#[cfg(test)]
 fn collect_markdown_files(
     root_dir: &Path,
     canonical_root_dir: &Path,
 ) -> Result<Vec<String>, String> {
+    let mut files = collect_markdown_file_entries(root_dir, canonical_root_dir)?
+        .into_iter()
+        .map(|metadata| metadata.relative_path)
+        .collect::<Vec<_>>();
+    files.sort();
+    Ok(files)
+}
+
+fn collect_markdown_file_entries(
+    root_dir: &Path,
+    canonical_root_dir: &Path,
+) -> Result<Vec<MarkdownFileMetadata>, String> {
     let mut files = Vec::new();
     visit_dir(root_dir, canonical_root_dir, root_dir, &mut files)?;
     Ok(files)
@@ -757,7 +813,7 @@ fn visit_dir(
     root_dir: &Path,
     canonical_root_dir: &Path,
     directory: &Path,
-    files: &mut Vec<String>,
+    files: &mut Vec<MarkdownFileMetadata>,
 ) -> Result<(), String> {
     let entries = match fs::read_dir(directory) {
         Ok(entries) => entries,
@@ -786,7 +842,7 @@ fn visit_dir(
 
         if is_markdown_file(&path) && canonical_path_is_inside_root(canonical_root_dir, &path) {
             if let Some(relative) = path_to_relative(root_dir, &path) {
-                files.push(relative);
+                files.push(markdown_file_metadata(relative, &path));
             }
         }
     }
@@ -837,12 +893,42 @@ fn visit_dir_streaming(
 
         if is_markdown_file(&path) && canonical_path_is_inside_root(root_dir, &path) {
             if let Some(relative) = path_to_relative(root_dir, &path) {
-                on_entry(ScanEntry::File(relative));
+                on_entry(ScanEntry::File(markdown_file_metadata(relative, &path)));
             }
         }
     }
 
     Ok(())
+}
+
+fn markdown_file_metadata(relative_path: String, path: &Path) -> MarkdownFileMetadata {
+    MarkdownFileMetadata {
+        relative_path,
+        modified_at: fs::metadata(path)
+            .ok()
+            .and_then(|metadata| metadata.modified().ok())
+            .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|duration| duration.as_millis() as u64),
+    }
+}
+
+fn merge_metadata(
+    target: &mut HashMap<String, MarkdownFileMetadata>,
+    incoming: &[MarkdownFileMetadata],
+) {
+    for metadata in incoming {
+        target.insert(metadata.relative_path.clone(), metadata.clone());
+    }
+}
+
+fn metadata_for_files(
+    files: &[String],
+    metadata: &HashMap<String, MarkdownFileMetadata>,
+) -> Vec<MarkdownFileMetadata> {
+    files
+        .iter()
+        .filter_map(|path| metadata.get(path).cloned())
+        .collect()
 }
 
 fn merge_sorted_unique(target: &mut Vec<String>, incoming: &[String]) {
@@ -1064,7 +1150,7 @@ mod tests {
         let mut skipped = Vec::new();
         let canonical_root = temp.canonical_path();
         visit_dir_streaming(&canonical_root, &canonical_root, &mut |entry| match entry {
-            ScanEntry::File(path) => files.push(path),
+            ScanEntry::File(metadata) => files.push(metadata.relative_path),
             ScanEntry::Skipped(path) => skipped.push(path),
         })
         .expect("streaming scan should succeed");
@@ -1074,6 +1160,24 @@ mod tests {
 
         assert_eq!(files, vec!["visible.md"]);
         assert_eq!(skipped, vec![".git"]);
+    }
+
+    #[test]
+    fn collect_markdown_file_entries_includes_modified_time_without_content() {
+        let temp = TestDir::new();
+        fs::write(
+            temp.path.join("visible.md"),
+            "# Secret content stays on disk\n",
+        )
+        .expect("markdown file should be written");
+
+        let canonical_root = temp.canonical_path();
+        let files = collect_markdown_file_entries(&canonical_root, &canonical_root)
+            .expect("scan should succeed");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].relative_path, "visible.md");
+        assert!(files[0].modified_at.is_some());
     }
 
     #[test]
@@ -1137,7 +1241,8 @@ mod tests {
         let event = Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content)))
             .add_path(temp.path.join("notes/a.md"));
 
-        let payload = classify_event(&event, &temp.path).expect("markdown modify should be reported");
+        let payload =
+            classify_event(&event, &temp.path).expect("markdown modify should be reported");
 
         assert_eq!(payload.changed_paths, vec!["notes/a.md"]);
         assert!(!payload.tree_changed);
@@ -1146,15 +1251,20 @@ mod tests {
     #[test]
     fn classify_event_marks_markdown_create_remove_and_rename_as_tree_changes() {
         let temp = TestDir::new();
-        let create_event = Event::new(EventKind::Create(CreateKind::File)).add_path(temp.path.join("created.md"));
-        let remove_event = Event::new(EventKind::Remove(RemoveKind::File)).add_path(temp.path.join("removed.md"));
+        let create_event =
+            Event::new(EventKind::Create(CreateKind::File)).add_path(temp.path.join("created.md"));
+        let remove_event =
+            Event::new(EventKind::Remove(RemoveKind::File)).add_path(temp.path.join("removed.md"));
         let rename_event = Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Both)))
             .add_path(temp.path.join("old.md"))
             .add_path(temp.path.join("new.md"));
 
-        let create_payload = classify_event(&create_event, &temp.path).expect("markdown create should be reported");
-        let remove_payload = classify_event(&remove_event, &temp.path).expect("markdown remove should be reported");
-        let rename_payload = classify_event(&rename_event, &temp.path).expect("markdown rename should be reported");
+        let create_payload =
+            classify_event(&create_event, &temp.path).expect("markdown create should be reported");
+        let remove_payload =
+            classify_event(&remove_event, &temp.path).expect("markdown remove should be reported");
+        let rename_payload =
+            classify_event(&rename_event, &temp.path).expect("markdown rename should be reported");
 
         assert!(create_payload.tree_changed);
         assert_eq!(create_payload.changed_paths, vec!["created.md"]);
@@ -1206,8 +1316,11 @@ mod tests {
         let text_file = temp.path.join("notes.txt");
         fs::write(&text_file, "not markdown\n").expect("text file should be written");
 
-        let error = resolve_target_from_args(Some(text_file.to_str().expect("path should be utf-8")), &temp.path)
-            .expect_err("non-markdown file should be rejected");
+        let error = resolve_target_from_args(
+            Some(text_file.to_str().expect("path should be utf-8")),
+            &temp.path,
+        )
+        .expect_err("non-markdown file should be rejected");
 
         assert!(error.contains("launch target must be a directory or markdown file"));
     }
@@ -1218,8 +1331,14 @@ mod tests {
         let document = temp.path.join("guide.md");
         fs::write(&document, "# Guide\n").expect("markdown file should be written");
 
-        let resolved = resolve_arg_path("guide.md", &temp.path).expect("relative path should resolve");
+        let resolved =
+            resolve_arg_path("guide.md", &temp.path).expect("relative path should resolve");
 
-        assert_eq!(resolved, document.canonicalize().expect("document should canonicalize"));
+        assert_eq!(
+            resolved,
+            document
+                .canonicalize()
+                .expect("document should canonicalize")
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,7 @@ struct InitialSession {
 struct MarkdownFileMetadata {
     relative_path: String,
     modified_at: Option<u64>,
+    size_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -902,13 +903,16 @@ fn visit_dir_streaming(
 }
 
 fn markdown_file_metadata(relative_path: String, path: &Path) -> MarkdownFileMetadata {
+    let metadata = fs::metadata(path).ok();
+
     MarkdownFileMetadata {
         relative_path,
-        modified_at: fs::metadata(path)
-            .ok()
+        modified_at: metadata
+            .as_ref()
             .and_then(|metadata| metadata.modified().ok())
             .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
             .map(|duration| duration.as_millis() as u64),
+        size_bytes: metadata.as_ref().map(|metadata| metadata.len()),
     }
 }
 
@@ -1163,13 +1167,10 @@ mod tests {
     }
 
     #[test]
-    fn collect_markdown_file_entries_includes_modified_time_without_content() {
+    fn collect_markdown_file_entries_includes_metadata_without_content() {
         let temp = TestDir::new();
-        fs::write(
-            temp.path.join("visible.md"),
-            "# Secret content stays on disk\n",
-        )
-        .expect("markdown file should be written");
+        let content = "# Secret content stays on disk\n";
+        fs::write(temp.path.join("visible.md"), content).expect("markdown file should be written");
 
         let canonical_root = temp.canonical_path();
         let files = collect_markdown_file_entries(&canonical_root, &canonical_root)
@@ -1178,6 +1179,7 @@ mod tests {
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].relative_path, "visible.md");
         assert!(files[0].modified_at.is_some());
+        assert_eq!(files[0].size_bytes, Some(content.len() as u64));
     }
 
     #[test]
@@ -1188,6 +1190,7 @@ mod tests {
             MarkdownFileMetadata {
                 relative_path: "notes/a.md".to_string(),
                 modified_at: Some(10),
+                size_bytes: Some(100),
             },
         );
         metadata.insert(
@@ -1195,6 +1198,7 @@ mod tests {
             MarkdownFileMetadata {
                 relative_path: "notes/b.md".to_string(),
                 modified_at: Some(20),
+                size_bytes: Some(200),
             },
         );
         metadata.insert(
@@ -1202,6 +1206,7 @@ mod tests {
             MarkdownFileMetadata {
                 relative_path: "stale.md".to_string(),
                 modified_at: Some(30),
+                size_bytes: Some(300),
             },
         );
 
@@ -1222,6 +1227,13 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![Some(20), Some(10)]
         );
+        assert_eq!(
+            payload
+                .iter()
+                .map(|entry| entry.size_bytes)
+                .collect::<Vec<_>>(),
+            vec![Some(200), Some(100)]
+        );
     }
 
     #[test]
@@ -1232,6 +1244,7 @@ mod tests {
             MarkdownFileMetadata {
                 relative_path: "notes/a.md".to_string(),
                 modified_at: Some(10),
+                size_bytes: Some(100),
             },
         );
 
@@ -1241,10 +1254,12 @@ mod tests {
                 MarkdownFileMetadata {
                     relative_path: "notes/a.md".to_string(),
                     modified_at: Some(100),
+                    size_bytes: Some(1_000),
                 },
                 MarkdownFileMetadata {
                     relative_path: "notes/b.md".to_string(),
                     modified_at: Some(200),
+                    size_bytes: Some(2_000),
                 },
             ],
         );
@@ -1260,6 +1275,12 @@ mod tests {
                 .get("notes/b.md")
                 .and_then(|entry| entry.modified_at),
             Some(200)
+        );
+        assert_eq!(
+            metadata
+                .get("notes/a.md")
+                .and_then(|entry| entry.size_bytes),
+            Some(1_000)
         );
         assert_eq!(metadata.len(), 2);
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ function App() {
   const error = useAppStore((state) => state.error);
   const rootDir = useAppStore((state) => state.rootDir);
   const files = useAppStore((state) => state.files);
+  const fileMetadata = useAppStore((state) => state.fileMetadata);
   const scanState = useAppStore((state) => state.scanState);
   const scanSkippedPaths = useAppStore((state) => state.scanSkippedPaths);
   const scanError = useAppStore((state) => state.scanError);
@@ -79,6 +80,7 @@ function App() {
                   <div className="h-[calc(100vh-72px)] overflow-hidden">
                     <FileTree
                       files={files}
+                      fileMetadata={fileMetadata}
                       scanState={scanState}
                       skippedCount={scanSkippedPaths.length}
                       selectedFile={selectedFile}
@@ -109,6 +111,7 @@ function App() {
               <div className="sticky top-4 h-[calc(100vh-8rem)]">
                 <FileTree
                   files={files}
+                  fileMetadata={fileMetadata}
                   scanState={scanState}
                   skippedCount={scanSkippedPaths.length}
                   selectedFile={selectedFile}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ function App() {
                   </SheetHeader>
                   <div className="h-[calc(100vh-72px)] overflow-hidden">
                     <FileTree
+                      rootDir={rootDir}
                       files={files}
                       fileMetadata={fileMetadata}
                       scanState={scanState}
@@ -110,6 +111,7 @@ function App() {
             <aside className="hidden min-h-0 lg:block">
               <div className="sticky top-4 h-[calc(100vh-8rem)]">
                 <FileTree
+                  rootDir={rootDir}
                   files={files}
                   fileMetadata={fileMetadata}
                   scanState={scanState}

--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -5,6 +5,7 @@ import {
   buildTree,
   filterFiles,
   flattenVisibleTree,
+  formatModifiedAt,
   parseSortMode,
   readStoredSortMode,
   treeNodeIndent,
@@ -154,6 +155,18 @@ describe("document tree sorting", () => {
 
     expect(tree.map((node) => node.path)).toEqual(["notes", "docs", "old.md"]);
     expect(tree[1]?.children.map((node) => node.path)).toEqual(["docs/newer.md", "docs/older.md"]);
+  });
+});
+
+describe("modified time labels", () => {
+  it("formats recent modified times without exposing file content", () => {
+    const now = Date.UTC(2026, 3, 28, 13, 0, 0);
+
+    expect(formatModifiedAt(null, now)).toBeNull();
+    expect(formatModifiedAt(now - 30_000, now)).toBe("방금 전");
+    expect(formatModifiedAt(now - 5 * 60_000, now)).toBe("5분 전");
+    expect(formatModifiedAt(now - 3 * 60 * 60_000, now)).toBe("3시간 전");
+    expect(formatModifiedAt(now - 2 * 24 * 60 * 60_000, now)).toBe("2일 전");
   });
 });
 

--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   DOCUMENT_TREE_SORT_MODE_STORAGE_KEY,
   buildTree,
+  documentTreeSortModeStorageKey,
   filterFiles,
   flattenVisibleTree,
   formatModifiedAt,
@@ -132,13 +133,16 @@ describe("document tree sorting", () => {
     expect(parseSortMode(null)).toBe("name");
   });
 
-  it("stores and restores the selected sort mode in session storage", () => {
-    const sessionStorage = installSessionStorageMock();
+  it("stores and restores the selected sort mode per root", () => {
+    const localStorage = installLocalStorageMock();
 
-    writeStoredSortMode("path");
+    writeStoredSortMode("/vault-a", "path");
+    writeStoredSortMode("/vault-b", "modified");
 
-    expect(sessionStorage.getItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY)).toBe("path");
-    expect(readStoredSortMode()).toBe("path");
+    expect(localStorage.getItem(documentTreeSortModeStorageKey("/vault-a"))).toBe("path");
+    expect(localStorage.getItem(`${DOCUMENT_TREE_SORT_MODE_STORAGE_KEY}:/vault-b`)).toBe("modified");
+    expect(readStoredSortMode("/vault-a")).toBe("path");
+    expect(readStoredSortMode("/vault-b")).toBe("modified");
   });
 
   it("sorts files and directories by newest modified time when metadata is available", () => {
@@ -170,17 +174,17 @@ describe("modified time labels", () => {
   });
 });
 
-function installSessionStorageMock() {
+function installLocalStorageMock() {
   const values = new Map<string, string>();
-  const sessionStorage = {
+  const localStorage = {
     getItem: (key: string) => values.get(key) ?? null,
     setItem: (key: string, value: string) => values.set(key, value),
   };
 
   Object.defineProperty(globalThis, "window", {
-    value: { sessionStorage },
+    value: { localStorage },
     configurable: true,
   });
 
-  return sessionStorage;
+  return localStorage;
 }

--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -127,7 +127,7 @@ describe("file tree structure", () => {
 describe("document tree sorting", () => {
   it("parses unknown sort modes as name sort", () => {
     expect(parseSortMode("path")).toBe("path");
-    expect(parseSortMode("modified")).toBe("name");
+    expect(parseSortMode("modified")).toBe("modified");
     expect(parseSortMode(null)).toBe("name");
   });
 
@@ -138,6 +138,22 @@ describe("document tree sorting", () => {
 
     expect(sessionStorage.getItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY)).toBe("path");
     expect(readStoredSortMode()).toBe("path");
+  });
+
+  it("sorts files and directories by newest modified time when metadata is available", () => {
+    const tree = buildTree(
+      ["old.md", "docs/older.md", "docs/newer.md", "notes/latest.md"],
+      "modified",
+      {
+        "old.md": { relativePath: "old.md", modifiedAt: 10 },
+        "docs/older.md": { relativePath: "docs/older.md", modifiedAt: 20 },
+        "docs/newer.md": { relativePath: "docs/newer.md", modifiedAt: 30 },
+        "notes/latest.md": { relativePath: "notes/latest.md", modifiedAt: 40 },
+      },
+    );
+
+    expect(tree.map((node) => node.path)).toEqual(["notes", "docs", "old.md"]);
+    expect(tree[1]?.children.map((node) => node.path)).toEqual(["docs/newer.md", "docs/older.md"]);
   });
 });
 

--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -131,6 +131,7 @@ describe("document tree sorting", () => {
   it("parses unknown sort modes as name sort", () => {
     expect(parseSortMode("path")).toBe("path");
     expect(parseSortMode("modified")).toBe("modified");
+    expect(parseSortMode("size")).toBe("size");
     expect(parseSortMode(null)).toBe("name");
   });
 
@@ -160,6 +161,22 @@ describe("document tree sorting", () => {
 
     expect(tree.map((node) => node.path)).toEqual(["notes", "docs", "old.md"]);
     expect(tree[1]?.children.map((node) => node.path)).toEqual(["docs/newer.md", "docs/older.md"]);
+  });
+
+  it("sorts files and directories by largest file size when metadata is available", () => {
+    const tree = buildTree(
+      ["small.md", "docs/medium.md", "docs/large.md", "notes/largest.md"],
+      "size",
+      {
+        "small.md": { relativePath: "small.md", modifiedAt: 10, sizeBytes: 10 },
+        "docs/medium.md": { relativePath: "docs/medium.md", modifiedAt: 20, sizeBytes: 200 },
+        "docs/large.md": { relativePath: "docs/large.md", modifiedAt: 30, sizeBytes: 300 },
+        "notes/largest.md": { relativePath: "notes/largest.md", modifiedAt: 40, sizeBytes: 400 },
+      },
+    );
+
+    expect(tree.map((node) => node.path)).toEqual(["notes", "docs", "small.md"]);
+    expect(tree[1]?.children.map((node) => node.path)).toEqual(["docs/large.md", "docs/medium.md"]);
   });
 });
 

--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -6,6 +6,7 @@ import {
   documentTreeSortModeStorageKey,
   filterFiles,
   flattenVisibleTree,
+  formatFileSize,
   formatModifiedAt,
   parseSortMode,
   readStoredSortMode,
@@ -162,7 +163,7 @@ describe("document tree sorting", () => {
   });
 });
 
-describe("modified time labels", () => {
+describe("metadata labels", () => {
   it("formats recent modified times without exposing file content", () => {
     const now = Date.UTC(2026, 3, 28, 13, 0, 0);
 
@@ -171,6 +172,15 @@ describe("modified time labels", () => {
     expect(formatModifiedAt(now - 5 * 60_000, now)).toBe("5분 전");
     expect(formatModifiedAt(now - 3 * 60 * 60_000, now)).toBe("3시간 전");
     expect(formatModifiedAt(now - 2 * 24 * 60 * 60_000, now)).toBe("2일 전");
+  });
+
+  it("formats file sizes from content-free metadata", () => {
+    expect(formatFileSize(null)).toBeNull();
+    expect(formatFileSize(0)).toBe("0 B");
+    expect(formatFileSize(512)).toBe("512 B");
+    expect(formatFileSize(1536)).toBe("1.5 KB");
+    expect(formatFileSize(12 * 1024)).toBe("12 KB");
+    expect(formatFileSize(2.5 * 1024 * 1024)).toBe("2.5 MB");
   });
 });
 

--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -150,10 +150,10 @@ describe("document tree sorting", () => {
       ["old.md", "docs/older.md", "docs/newer.md", "notes/latest.md"],
       "modified",
       {
-        "old.md": { relativePath: "old.md", modifiedAt: 10 },
-        "docs/older.md": { relativePath: "docs/older.md", modifiedAt: 20 },
-        "docs/newer.md": { relativePath: "docs/newer.md", modifiedAt: 30 },
-        "notes/latest.md": { relativePath: "notes/latest.md", modifiedAt: 40 },
+        "old.md": { relativePath: "old.md", modifiedAt: 10, sizeBytes: 100 },
+        "docs/older.md": { relativePath: "docs/older.md", modifiedAt: 20, sizeBytes: 200 },
+        "docs/newer.md": { relativePath: "docs/newer.md", modifiedAt: 30, sizeBytes: 300 },
+        "notes/latest.md": { relativePath: "notes/latest.md", modifiedAt: 40, sizeBytes: 400 },
       },
     );
 

--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import { buildTree, filterFiles, flattenVisibleTree, treeNodeIndent } from "./file-tree";
+import {
+  DOCUMENT_TREE_SORT_MODE_STORAGE_KEY,
+  buildTree,
+  filterFiles,
+  flattenVisibleTree,
+  parseSortMode,
+  readStoredSortMode,
+  treeNodeIndent,
+  writeStoredSortMode,
+} from "./file-tree";
 
 const files = ["docs/guide.md", "notes/today.md", "projects/markmini/plan.md"];
 
@@ -114,3 +123,35 @@ describe("file tree structure", () => {
     expect([0, 1, 2, 3].map(treeNodeIndent)).toEqual(["8px", "28px", "48px", "68px"]);
   });
 });
+
+describe("document tree sorting", () => {
+  it("parses unknown sort modes as name sort", () => {
+    expect(parseSortMode("path")).toBe("path");
+    expect(parseSortMode("modified")).toBe("name");
+    expect(parseSortMode(null)).toBe("name");
+  });
+
+  it("stores and restores the selected sort mode in session storage", () => {
+    const sessionStorage = installSessionStorageMock();
+
+    writeStoredSortMode("path");
+
+    expect(sessionStorage.getItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY)).toBe("path");
+    expect(readStoredSortMode()).toBe("path");
+  });
+});
+
+function installSessionStorageMock() {
+  const values = new Map<string, string>();
+  const sessionStorage = {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+
+  Object.defineProperty(globalThis, "window", {
+    value: { sessionStorage },
+    configurable: true,
+  });
+
+  return sessionStorage;
+}

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -13,6 +13,7 @@ export type DocumentTreeSortMode = "name" | "path" | "modified";
 export const DOCUMENT_TREE_SORT_MODE_STORAGE_KEY = "markmini.documentTree.sortMode";
 
 interface FileTreeProps {
+  rootDir: string | null;
   files: string[];
   fileMetadata: Record<string, MarkdownFileMetadata>;
   scanState: ScanStatus;
@@ -21,9 +22,9 @@ interface FileTreeProps {
   onSelect: (relativePath: string) => void;
 }
 
-export function FileTree({ files, fileMetadata, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
+export function FileTree({ rootDir, files, fileMetadata, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [sortMode, setSortMode] = useState<DocumentTreeSortMode>(readStoredSortMode);
+  const [sortMode, setSortMode] = useState<DocumentTreeSortMode>(() => readStoredSortMode(rootDir));
   const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredFiles = useMemo(() => filterFiles(files, normalizedSearchQuery), [files, normalizedSearchQuery]);
   const tree = useMemo(() => buildTree(filteredFiles, sortMode, fileMetadata), [filteredFiles, fileMetadata, sortMode]);
@@ -35,8 +36,12 @@ export function FileTree({ files, fileMetadata, scanState, skippedCount, selecte
   const treeRef = useRef<HTMLUListElement | null>(null);
 
   useEffect(() => {
-    writeStoredSortMode(sortMode);
-  }, [sortMode]);
+    setSortMode(readStoredSortMode(rootDir));
+  }, [rootDir]);
+
+  useEffect(() => {
+    writeStoredSortMode(rootDir, sortMode);
+  }, [rootDir, sortMode]);
 
   useEffect(() => {
     setExpandedPaths((current) => {
@@ -408,27 +413,31 @@ export function filterFiles(files: string[], normalizedSearchQuery: string) {
   });
 }
 
-export function readStoredSortMode(): DocumentTreeSortMode {
+export function documentTreeSortModeStorageKey(rootDir: string | null) {
+  return rootDir ? `${DOCUMENT_TREE_SORT_MODE_STORAGE_KEY}:${rootDir}` : DOCUMENT_TREE_SORT_MODE_STORAGE_KEY;
+}
+
+export function readStoredSortMode(rootDir: string | null = null): DocumentTreeSortMode {
   if (typeof window === "undefined") {
     return "name";
   }
 
   try {
-    return parseSortMode(window.sessionStorage.getItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY));
+    return parseSortMode(window.localStorage.getItem(documentTreeSortModeStorageKey(rootDir)));
   } catch {
     return "name";
   }
 }
 
-export function writeStoredSortMode(sortMode: DocumentTreeSortMode) {
+export function writeStoredSortMode(rootDir: string | null, sortMode: DocumentTreeSortMode) {
   if (typeof window === "undefined") {
     return;
   }
 
   try {
-    window.sessionStorage.setItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY, sortMode);
+    window.localStorage.setItem(documentTreeSortModeStorageKey(rootDir), sortMode);
   } catch {
-    // Keep sorting usable even if session storage is unavailable.
+    // Keep sorting usable even if local storage is unavailable.
   }
 }
 

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -234,6 +234,8 @@ export function FileTree({ files, fileMetadata, scanState, skippedCount, selecte
                     node={node}
                     selectedFile={selectedFile}
                     onSelect={onSelect}
+                    fileMetadata={fileMetadata}
+                    sortMode={sortMode}
                     depth={depth}
                     expanded={expandedPaths.has(node.path)}
                     focused={currentFocusPath === node.path}
@@ -261,6 +263,8 @@ function TreeNode({
   node,
   selectedFile,
   onSelect,
+  fileMetadata,
+  sortMode,
   depth,
   expanded,
   focused,
@@ -270,6 +274,8 @@ function TreeNode({
   node: TreeNodeData;
   selectedFile: string | null;
   onSelect: (relativePath: string) => void;
+  fileMetadata: Record<string, MarkdownFileMetadata>;
+  sortMode: DocumentTreeSortMode;
   depth: number;
   expanded: boolean;
   focused: boolean;
@@ -279,6 +285,8 @@ function TreeNode({
   const isDirectory = node.kind === "directory";
   const isSelected = selectedFile === node.path;
   const label = isDirectory ? node.name : fileLabel(node.path);
+  const modifiedLabel =
+    sortMode === "modified" && node.kind === "file" ? formatModifiedAt(fileMetadata[node.path]?.modifiedAt) : null;
 
   if (node.kind === "directory") {
     return (
@@ -333,7 +341,12 @@ function TreeNode({
         )}
       >
         <FileText className={cn("h-4 w-4 shrink-0", isSelected ? "opacity-90" : "text-muted-foreground")} />
-        <span className="truncate">{label}</span>
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        {modifiedLabel ? (
+          <span className={cn("ml-auto shrink-0 text-[11px] tabular-nums", isSelected ? "opacity-80" : "text-muted-foreground")}>
+            {modifiedLabel}
+          </span>
+        ) : null}
       </button>
     </li>
   );
@@ -501,4 +514,36 @@ function modifiedAt(node: TreeNodeData, fileMetadata: Record<string, MarkdownFil
   }
 
   return Math.max(0, ...node.children.map((child) => modifiedAt(child, fileMetadata)));
+}
+
+export function formatModifiedAt(modifiedAt: number | null | undefined, now = Date.now()): string | null {
+  if (!modifiedAt) {
+    return null;
+  }
+
+  const diffMs = Math.max(0, now - modifiedAt);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (diffMs < minute) {
+    return "방금 전";
+  }
+
+  if (diffMs < hour) {
+    return `${Math.floor(diffMs / minute)}분 전`;
+  }
+
+  if (diffMs < day) {
+    return `${Math.floor(diffMs / hour)}시간 전`;
+  }
+
+  if (diffMs < 7 * day) {
+    return `${Math.floor(diffMs / day)}일 전`;
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(modifiedAt));
 }

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -8,7 +8,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import type { ScanStatus } from "@/types/content";
 import type { MarkdownFileMetadata } from "@/types/content";
 
-export type DocumentTreeSortMode = "name" | "path" | "modified";
+export type DocumentTreeSortMode = "name" | "path" | "modified" | "size";
 
 export const DOCUMENT_TREE_SORT_MODE_STORAGE_KEY = "markmini.documentTree.sortMode";
 
@@ -201,6 +201,7 @@ export function FileTree({ rootDir, files, fileMetadata, scanState, skippedCount
             <option value="name">이름순</option>
             <option value="path">경로순</option>
             <option value="modified">수정일순</option>
+            <option value="size">크기순</option>
           </select>
         </div>
         {scanState === "scanning" || skippedCount > 0 ? (
@@ -443,7 +444,7 @@ export function writeStoredSortMode(rootDir: string | null, sortMode: DocumentTr
 }
 
 export function parseSortMode(value: unknown): DocumentTreeSortMode {
-  return value === "path" || value === "modified" ? value : "name";
+  return value === "path" || value === "modified" || value === "size" ? value : "name";
 }
 
 export function buildTree(
@@ -512,6 +513,13 @@ function sortTree(
         }
       }
 
+      if (sortMode === "size") {
+        const sizeComparison = sizeBytes(right, fileMetadata) - sizeBytes(left, fileMetadata);
+        if (sizeComparison !== 0) {
+          return sizeComparison;
+        }
+      }
+
       const leftValue = sortMode === "path" ? left.path : left.name;
       const rightValue = sortMode === "path" ? right.path : right.name;
       return leftValue.localeCompare(rightValue);
@@ -524,6 +532,14 @@ function modifiedAt(node: TreeNodeData, fileMetadata: Record<string, MarkdownFil
   }
 
   return Math.max(0, ...node.children.map((child) => modifiedAt(child, fileMetadata)));
+}
+
+function sizeBytes(node: TreeNodeData, fileMetadata: Record<string, MarkdownFileMetadata>): number {
+  if (node.kind === "file") {
+    return fileMetadata[node.path]?.sizeBytes ?? 0;
+  }
+
+  return Math.max(0, ...node.children.map((child) => sizeBytes(child, fileMetadata)));
 }
 
 export function formatModifiedAt(modifiedAt: number | null | undefined, now = Date.now()): string | null {

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -7,6 +7,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type { ScanStatus } from "@/types/content";
 
+export type DocumentTreeSortMode = "name" | "path";
+
+export const DOCUMENT_TREE_SORT_MODE_STORAGE_KEY = "markmini.documentTree.sortMode";
+
 interface FileTreeProps {
   files: string[];
   scanState: ScanStatus;
@@ -17,15 +21,20 @@ interface FileTreeProps {
 
 export function FileTree({ files, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
   const [searchQuery, setSearchQuery] = useState("");
+  const [sortMode, setSortMode] = useState<DocumentTreeSortMode>(readStoredSortMode);
   const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredFiles = useMemo(() => filterFiles(files, normalizedSearchQuery), [files, normalizedSearchQuery]);
-  const tree = useMemo(() => buildTree(filteredFiles), [filteredFiles]);
+  const tree = useMemo(() => buildTree(filteredFiles, sortMode), [filteredFiles, sortMode]);
   const directoryPaths = useMemo(() => collectDirectoryPaths(tree), [tree]);
   const selectedFileIsFilteredOut = Boolean(normalizedSearchQuery && selectedFile && !filteredFiles.includes(selectedFile));
   const hasInitializedExpansionRef = useRef(false);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set());
   const [focusedPath, setFocusedPath] = useState<string | null>(selectedFile);
   const treeRef = useRef<HTMLUListElement | null>(null);
+
+  useEffect(() => {
+    writeStoredSortMode(sortMode);
+  }, [sortMode]);
 
   useEffect(() => {
     setExpandedPaths((current) => {
@@ -173,6 +182,18 @@ export function FileTree({ files, scanState, skippedCount, selectedFile, onSelec
             aria-label="문서 검색"
             className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm text-foreground outline-none transition placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           />
+        </div>
+        <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+          <span>정렬</span>
+          <select
+            value={sortMode}
+            onChange={(event) => setSortMode(parseSortMode(event.target.value))}
+            aria-label="문서 트리 정렬"
+            className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <option value="name">이름순</option>
+            <option value="path">경로순</option>
+          </select>
         </div>
         {scanState === "scanning" || skippedCount > 0 ? (
           <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
@@ -371,14 +392,42 @@ export function filterFiles(files: string[], normalizedSearchQuery: string) {
   });
 }
 
-export function buildTree(files: string[]) {
+export function readStoredSortMode(): DocumentTreeSortMode {
+  if (typeof window === "undefined") {
+    return "name";
+  }
+
+  try {
+    return parseSortMode(window.sessionStorage.getItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY));
+  } catch {
+    return "name";
+  }
+}
+
+export function writeStoredSortMode(sortMode: DocumentTreeSortMode) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(DOCUMENT_TREE_SORT_MODE_STORAGE_KEY, sortMode);
+  } catch {
+    // Keep sorting usable even if session storage is unavailable.
+  }
+}
+
+export function parseSortMode(value: unknown): DocumentTreeSortMode {
+  return value === "path" ? "path" : "name";
+}
+
+export function buildTree(files: string[], sortMode: DocumentTreeSortMode = "name") {
   const root: TreeNodeData[] = [];
 
   for (const file of files) {
     insertNode(root, file.split("/"), "", file);
   }
 
-  return sortTree(root);
+  return sortTree(root, sortMode);
 }
 
 function insertNode(nodes: TreeNodeData[], segments: string[], parentPath: string, originalPath: string) {
@@ -411,17 +460,19 @@ function insertNode(nodes: TreeNodeData[], segments: string[], parentPath: strin
   }
 }
 
-function sortTree(nodes: TreeNodeData[]): TreeNodeData[] {
+function sortTree(nodes: TreeNodeData[], sortMode: DocumentTreeSortMode): TreeNodeData[] {
   return nodes
     .map((node) => ({
       ...node,
-      children: sortTree(node.children),
+      children: sortTree(node.children, sortMode),
     }))
     .sort((left, right) => {
       if (left.kind !== right.kind) {
         return left.kind === "directory" ? -1 : 1;
       }
 
-      return left.name.localeCompare(right.name);
+      const leftValue = sortMode === "path" ? left.path : left.name;
+      const rightValue = sortMode === "path" ? right.path : right.name;
+      return leftValue.localeCompare(rightValue);
     });
 }

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -292,6 +292,7 @@ function TreeNode({
   const label = isDirectory ? node.name : fileLabel(node.path);
   const modifiedLabel =
     sortMode === "modified" && node.kind === "file" ? formatModifiedAt(fileMetadata[node.path]?.modifiedAt) : null;
+  const sizeLabel = node.kind === "file" ? formatFileSize(fileMetadata[node.path]?.sizeBytes) : null;
 
   if (node.kind === "directory") {
     return (
@@ -347,9 +348,9 @@ function TreeNode({
       >
         <FileText className={cn("h-4 w-4 shrink-0", isSelected ? "opacity-90" : "text-muted-foreground")} />
         <span className="min-w-0 flex-1 truncate">{label}</span>
-        {modifiedLabel ? (
+        {modifiedLabel || sizeLabel ? (
           <span className={cn("ml-auto shrink-0 text-[11px] tabular-nums", isSelected ? "opacity-80" : "text-muted-foreground")}>
-            {modifiedLabel}
+            {modifiedLabel ?? sizeLabel}
           </span>
         ) : null}
       </button>
@@ -555,4 +556,25 @@ export function formatModifiedAt(modifiedAt: number | null | undefined, now = Da
     month: "short",
     day: "numeric",
   }).format(new Date(modifiedAt));
+}
+
+export function formatFileSize(sizeBytes: number | null | undefined): string | null {
+  if (sizeBytes == null) {
+    return null;
+  }
+
+  if (sizeBytes < 1024) {
+    return `${sizeBytes} B`;
+  }
+
+  const units = ["KB", "MB", "GB"];
+  let value = sizeBytes / 1024;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} ${units[unitIndex]}`;
 }

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -6,25 +6,27 @@ import { cn } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type { ScanStatus } from "@/types/content";
+import type { MarkdownFileMetadata } from "@/types/content";
 
-export type DocumentTreeSortMode = "name" | "path";
+export type DocumentTreeSortMode = "name" | "path" | "modified";
 
 export const DOCUMENT_TREE_SORT_MODE_STORAGE_KEY = "markmini.documentTree.sortMode";
 
 interface FileTreeProps {
   files: string[];
+  fileMetadata: Record<string, MarkdownFileMetadata>;
   scanState: ScanStatus;
   skippedCount: number;
   selectedFile: string | null;
   onSelect: (relativePath: string) => void;
 }
 
-export function FileTree({ files, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
+export function FileTree({ files, fileMetadata, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [sortMode, setSortMode] = useState<DocumentTreeSortMode>(readStoredSortMode);
   const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredFiles = useMemo(() => filterFiles(files, normalizedSearchQuery), [files, normalizedSearchQuery]);
-  const tree = useMemo(() => buildTree(filteredFiles, sortMode), [filteredFiles, sortMode]);
+  const tree = useMemo(() => buildTree(filteredFiles, sortMode, fileMetadata), [filteredFiles, fileMetadata, sortMode]);
   const directoryPaths = useMemo(() => collectDirectoryPaths(tree), [tree]);
   const selectedFileIsFilteredOut = Boolean(normalizedSearchQuery && selectedFile && !filteredFiles.includes(selectedFile));
   const hasInitializedExpansionRef = useRef(false);
@@ -193,6 +195,7 @@ export function FileTree({ files, scanState, skippedCount, selectedFile, onSelec
           >
             <option value="name">이름순</option>
             <option value="path">경로순</option>
+            <option value="modified">수정일순</option>
           </select>
         </div>
         {scanState === "scanning" || skippedCount > 0 ? (
@@ -417,17 +420,21 @@ export function writeStoredSortMode(sortMode: DocumentTreeSortMode) {
 }
 
 export function parseSortMode(value: unknown): DocumentTreeSortMode {
-  return value === "path" ? "path" : "name";
+  return value === "path" || value === "modified" ? value : "name";
 }
 
-export function buildTree(files: string[], sortMode: DocumentTreeSortMode = "name") {
+export function buildTree(
+  files: string[],
+  sortMode: DocumentTreeSortMode = "name",
+  fileMetadata: Record<string, MarkdownFileMetadata> = {},
+) {
   const root: TreeNodeData[] = [];
 
   for (const file of files) {
     insertNode(root, file.split("/"), "", file);
   }
 
-  return sortTree(root, sortMode);
+  return sortTree(root, sortMode, fileMetadata);
 }
 
 function insertNode(nodes: TreeNodeData[], segments: string[], parentPath: string, originalPath: string) {
@@ -460,19 +467,38 @@ function insertNode(nodes: TreeNodeData[], segments: string[], parentPath: strin
   }
 }
 
-function sortTree(nodes: TreeNodeData[], sortMode: DocumentTreeSortMode): TreeNodeData[] {
+function sortTree(
+  nodes: TreeNodeData[],
+  sortMode: DocumentTreeSortMode,
+  fileMetadata: Record<string, MarkdownFileMetadata>,
+): TreeNodeData[] {
   return nodes
     .map((node) => ({
       ...node,
-      children: sortTree(node.children, sortMode),
+      children: sortTree(node.children, sortMode, fileMetadata),
     }))
     .sort((left, right) => {
       if (left.kind !== right.kind) {
         return left.kind === "directory" ? -1 : 1;
       }
 
+      if (sortMode === "modified") {
+        const modifiedComparison = modifiedAt(right, fileMetadata) - modifiedAt(left, fileMetadata);
+        if (modifiedComparison !== 0) {
+          return modifiedComparison;
+        }
+      }
+
       const leftValue = sortMode === "path" ? left.path : left.name;
       const rightValue = sortMode === "path" ? right.path : right.name;
       return leftValue.localeCompare(rightValue);
     });
+}
+
+function modifiedAt(node: TreeNodeData, fileMetadata: Record<string, MarkdownFileMetadata>): number {
+  if (node.kind === "file") {
+    return fileMetadata[node.path]?.modifiedAt ?? 0;
+  }
+
+  return Math.max(0, ...node.children.map((child) => modifiedAt(child, fileMetadata)));
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
-import type { InitialSession, MarkdownDocument, ScanStatus } from "@/types/content";
+import type { InitialSession, MarkdownDocument, MarkdownFileMetadata, ScanStatus } from "@/types/content";
 
 export interface FsChangePayload {
   changedPaths: string[];
@@ -10,6 +10,7 @@ export interface FsChangePayload {
 
 export interface ScanProgressPayload {
   files: string[];
+  fileMetadata: MarkdownFileMetadata[];
   selectedFile: string | null;
   status: ScanStatus;
   skippedPaths: string[];

--- a/src/store/app-store.test.ts
+++ b/src/store/app-store.test.ts
@@ -37,6 +37,7 @@ function resetStore() {
     error: null,
     rootDir: null,
     files: [],
+    fileMetadata: {},
     fileSet: new Set(),
     scanState: "idle",
     scanSkippedPaths: [],
@@ -64,6 +65,7 @@ describe("viewer app store", () => {
     vi.mocked(getInitialSession).mockResolvedValue({
       rootDir: "/vault",
       files: ["notes/a.md"],
+      fileMetadata: [{ relativePath: "notes/a.md", modifiedAt: 10 }],
       selectedFile: "notes/a.md",
     });
     vi.mocked(readMarkdownFile).mockResolvedValue(markdownDocument("notes/a.md", "# Title\n"));
@@ -114,6 +116,7 @@ describe("viewer app store", () => {
     vi.mocked(refreshSession).mockResolvedValue({
       rootDir: "/vault",
       files: ["notes/a.md", "notes/b.md"],
+      fileMetadata: [{ relativePath: "notes/a.md", modifiedAt: 20 }],
       selectedFile: "notes/a.md",
     });
     vi.mocked(readMarkdownFile).mockResolvedValue(markdownDocument("notes/a.md", "# Reloaded\n", []));

--- a/src/store/app-store.test.ts
+++ b/src/store/app-store.test.ts
@@ -65,7 +65,7 @@ describe("viewer app store", () => {
     vi.mocked(getInitialSession).mockResolvedValue({
       rootDir: "/vault",
       files: ["notes/a.md"],
-      fileMetadata: [{ relativePath: "notes/a.md", modifiedAt: 10 }],
+      fileMetadata: [{ relativePath: "notes/a.md", modifiedAt: 10, sizeBytes: 100 }],
       selectedFile: "notes/a.md",
     });
     vi.mocked(readMarkdownFile).mockResolvedValue(markdownDocument("notes/a.md", "# Title\n"));
@@ -116,7 +116,7 @@ describe("viewer app store", () => {
     vi.mocked(refreshSession).mockResolvedValue({
       rootDir: "/vault",
       files: ["notes/a.md", "notes/b.md"],
-      fileMetadata: [{ relativePath: "notes/a.md", modifiedAt: 20 }],
+      fileMetadata: [{ relativePath: "notes/a.md", modifiedAt: 20, sizeBytes: 200 }],
       selectedFile: "notes/a.md",
     });
     vi.mocked(readMarkdownFile).mockResolvedValue(markdownDocument("notes/a.md", "# Reloaded\n", []));

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 import { extractHeadings } from "@/lib/markdown";
 import { getInitialSession, readMarkdownFile, refreshSession, type ScanProgressPayload } from "@/lib/tauri";
-import type { HeadingItem, ScanStatus } from "@/types/content";
+import type { HeadingItem, MarkdownFileMetadata, ScanStatus } from "@/types/content";
 
 type BootstrapState = "idle" | "loading" | "ready" | "error";
 type DocumentState = "idle" | "loading" | "ready" | "error";
@@ -12,6 +12,7 @@ interface AppStore {
   error: string | null;
   rootDir: string | null;
   files: string[];
+  fileMetadata: Record<string, MarkdownFileMetadata>;
   fileSet: ReadonlySet<string>;
   scanState: ScanStatus;
   scanSkippedPaths: string[];
@@ -39,6 +40,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   error: null,
   rootDir: null,
   files: [],
+  fileMetadata: {},
   fileSet: new Set(),
   scanState: "idle",
   scanSkippedPaths: [],
@@ -69,6 +71,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     set({
       bootstrapState: state.bootstrapState === "loading" ? "ready" : state.bootstrapState,
       files,
+      fileMetadata: mergeFileMetadata(state.fileMetadata, payload.fileMetadata),
       fileSet,
       scanState: payload.status,
       scanSkippedPaths,
@@ -99,6 +102,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         bootstrapState: "ready",
         rootDir: session.rootDir,
         files,
+        fileMetadata: mergeFileMetadata({}, session.fileMetadata),
         fileSet,
         selectedFile: session.selectedFile,
       });
@@ -181,6 +185,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       set({
         rootDir: session.rootDir,
         files,
+        fileMetadata: mergeFileMetadata({}, session.fileMetadata),
         fileSet,
         selectedFile,
         scanState: "completed",
@@ -258,4 +263,19 @@ function mergeSortedUnique(current: string[], currentSet: ReadonlySet<string>, i
   }
 
   return { values: [...next].sort(), valueSet: next };
+}
+
+export function mergeFileMetadata(
+  current: Record<string, MarkdownFileMetadata>,
+  incoming: MarkdownFileMetadata[],
+): Record<string, MarkdownFileMetadata> {
+  if (incoming.length === 0) {
+    return current;
+  }
+
+  const next = { ...current };
+  for (const metadata of incoming) {
+    next[metadata.relativePath] = metadata;
+  }
+  return next;
 }

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -14,6 +14,7 @@ export interface InitialSession {
 export interface MarkdownFileMetadata {
   relativePath: string;
   modifiedAt: number | null;
+  sizeBytes: number | null;
 }
 
 export type ScanStatus = "idle" | "scanning" | "completed" | "error";

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -7,7 +7,13 @@ export interface HeadingItem {
 export interface InitialSession {
   rootDir: string;
   files: string[];
+  fileMetadata: MarkdownFileMetadata[];
   selectedFile: string | null;
+}
+
+export interface MarkdownFileMetadata {
+  relativePath: string;
+  modifiedAt: number | null;
 }
 
 export type ScanStatus = "idle" | "scanning" | "completed" | "error";


### PR DESCRIPTION
## Summary
- add a size sort option to the document tree sort control
- sort files and directories by largest descendant/file size first
- preserve existing fallback ordering when size metadata is missing
- add focused size-sort tests

## Validation
- pnpm test
- pnpm typecheck
- pnpm build
- cargo test --manifest-path src-tauri/Cargo.toml

Stacked after #125.
Closes #83