### PR TITLE
feat: add document tree sort direction

### DIFF
--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -1,16 +1,22 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DOCUMENT_TREE_SORT_DIRECTION_STORAGE_KEY,
   DOCUMENT_TREE_SORT_MODE_STORAGE_KEY,
   buildTree,
+  defaultSortDirection,
+  documentTreeSortDirectionStorageKey,
   documentTreeSortModeStorageKey,
   filterFiles,
   flattenVisibleTree,
   formatFileSize,
   formatModifiedAt,
+  parseSortDirection,
   parseSortMode,
+  readStoredSortDirection,
   readStoredSortMode,
   treeNodeIndent,
+  writeStoredSortDirection,
   writeStoredSortMode,
 } from "./file-tree";
 
@@ -135,6 +141,14 @@ describe("document tree sorting", () => {
     expect(parseSortMode(null)).toBe("name");
   });
 
+  it("defaults sort direction by sort mode", () => {
+    expect(defaultSortDirection("name")).toBe("asc");
+    expect(defaultSortDirection("path")).toBe("asc");
+    expect(defaultSortDirection("modified")).toBe("desc");
+    expect(defaultSortDirection("size")).toBe("desc");
+    expect(parseSortDirection("sideways", "size")).toBe("desc");
+  });
+
   it("stores and restores the selected sort mode per root", () => {
     const localStorage = installLocalStorageMock();
 
@@ -145,6 +159,18 @@ describe("document tree sorting", () => {
     expect(localStorage.getItem(`${DOCUMENT_TREE_SORT_MODE_STORAGE_KEY}:/vault-b`)).toBe("modified");
     expect(readStoredSortMode("/vault-a")).toBe("path");
     expect(readStoredSortMode("/vault-b")).toBe("modified");
+  });
+
+  it("stores and restores the selected sort direction per root", () => {
+    const localStorage = installLocalStorageMock();
+
+    writeStoredSortDirection("/vault-a", "desc");
+    writeStoredSortDirection("/vault-b", "asc");
+
+    expect(localStorage.getItem(documentTreeSortDirectionStorageKey("/vault-a"))).toBe("desc");
+    expect(localStorage.getItem(`${DOCUMENT_TREE_SORT_DIRECTION_STORAGE_KEY}:/vault-b`)).toBe("asc");
+    expect(readStoredSortDirection("/vault-a", "name")).toBe("desc");
+    expect(readStoredSortDirection("/vault-b", "modified")).toBe("asc");
   });
 
   it("sorts files and directories by newest modified time when metadata is available", () => {
@@ -177,6 +203,26 @@ describe("document tree sorting", () => {
 
     expect(tree.map((node) => node.path)).toEqual(["notes", "docs", "small.md"]);
     expect(tree[1]?.children.map((node) => node.path)).toEqual(["docs/large.md", "docs/medium.md"]);
+  });
+
+  it("reverses same-kind tree ordering when descending direction is selected", () => {
+    const tree = buildTree(["a.md", "c.md", "b.md", "docs/a.md"], "name", {}, "desc");
+
+    expect(tree.map((node) => node.path)).toEqual(["docs", "c.md", "b.md", "a.md"]);
+  });
+
+  it("reverses metadata sorting when ascending direction is selected", () => {
+    const tree = buildTree(
+      ["small.md", "large.md"],
+      "size",
+      {
+        "small.md": { relativePath: "small.md", modifiedAt: 10, sizeBytes: 10 },
+        "large.md": { relativePath: "large.md", modifiedAt: 20, sizeBytes: 1000 },
+      },
+      "asc",
+    );
+
+    expect(tree.map((node) => node.path)).toEqual(["small.md", "large.md"]);
   });
 });
 

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -9,8 +9,10 @@ import type { ScanStatus } from "@/types/content";
 import type { MarkdownFileMetadata } from "@/types/content";
 
 export type DocumentTreeSortMode = "name" | "path" | "modified" | "size";
+export type DocumentTreeSortDirection = "asc" | "desc";
 
 export const DOCUMENT_TREE_SORT_MODE_STORAGE_KEY = "markmini.documentTree.sortMode";
+export const DOCUMENT_TREE_SORT_DIRECTION_STORAGE_KEY = "markmini.documentTree.sortDirection";
 
 interface FileTreeProps {
   rootDir: string | null;
@@ -25,9 +27,15 @@ interface FileTreeProps {
 export function FileTree({ rootDir, files, fileMetadata, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [sortMode, setSortMode] = useState<DocumentTreeSortMode>(() => readStoredSortMode(rootDir));
+  const [sortDirection, setSortDirection] = useState<DocumentTreeSortDirection>(() =>
+    readStoredSortDirection(rootDir, readStoredSortMode(rootDir)),
+  );
   const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredFiles = useMemo(() => filterFiles(files, normalizedSearchQuery), [files, normalizedSearchQuery]);
-  const tree = useMemo(() => buildTree(filteredFiles, sortMode, fileMetadata), [filteredFiles, fileMetadata, sortMode]);
+  const tree = useMemo(
+    () => buildTree(filteredFiles, sortMode, fileMetadata, sortDirection),
+    [filteredFiles, fileMetadata, sortDirection, sortMode],
+  );
   const directoryPaths = useMemo(() => collectDirectoryPaths(tree), [tree]);
   const selectedFileIsFilteredOut = Boolean(normalizedSearchQuery && selectedFile && !filteredFiles.includes(selectedFile));
   const hasInitializedExpansionRef = useRef(false);
@@ -36,12 +44,18 @@ export function FileTree({ rootDir, files, fileMetadata, scanState, skippedCount
   const treeRef = useRef<HTMLUListElement | null>(null);
 
   useEffect(() => {
-    setSortMode(readStoredSortMode(rootDir));
+    const storedSortMode = readStoredSortMode(rootDir);
+    setSortMode(storedSortMode);
+    setSortDirection(readStoredSortDirection(rootDir, storedSortMode));
   }, [rootDir]);
 
   useEffect(() => {
     writeStoredSortMode(rootDir, sortMode);
   }, [rootDir, sortMode]);
+
+  useEffect(() => {
+    writeStoredSortDirection(rootDir, sortDirection);
+  }, [rootDir, sortDirection]);
 
   useEffect(() => {
     setExpandedPaths((current) => {
@@ -95,6 +109,12 @@ export function FileTree({ rootDir, files, fileMetadata, scanState, skippedCount
       }
       return next;
     });
+  };
+
+  const handleSortModeChange = (value: string) => {
+    const nextSortMode = parseSortMode(value);
+    setSortMode(nextSortMode);
+    setSortDirection(defaultSortDirection(nextSortMode));
   };
 
   const handleTreeKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
@@ -192,17 +212,28 @@ export function FileTree({ rootDir, files, fileMetadata, scanState, skippedCount
         </div>
         <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
           <span>정렬</span>
-          <select
-            value={sortMode}
-            onChange={(event) => setSortMode(parseSortMode(event.target.value))}
-            aria-label="문서 트리 정렬"
-            className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <option value="name">이름순</option>
-            <option value="path">경로순</option>
-            <option value="modified">수정일순</option>
-            <option value="size">크기순</option>
-          </select>
+          <div className="flex items-center gap-2">
+            <select
+              value={sortMode}
+              onChange={(event) => handleSortModeChange(event.target.value)}
+              aria-label="문서 트리 정렬"
+              className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <option value="name">이름순</option>
+              <option value="path">경로순</option>
+              <option value="modified">수정일순</option>
+              <option value="size">크기순</option>
+            </select>
+            <select
+              value={sortDirection}
+              onChange={(event) => setSortDirection(parseSortDirection(event.target.value, sortMode))}
+              aria-label="문서 트리 정렬 방향"
+              className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <option value="asc">오름차순</option>
+              <option value="desc">내림차순</option>
+            </select>
+          </div>
         </div>
         {scanState === "scanning" || skippedCount > 0 ? (
           <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
@@ -419,6 +450,10 @@ export function documentTreeSortModeStorageKey(rootDir: string | null) {
   return rootDir ? `${DOCUMENT_TREE_SORT_MODE_STORAGE_KEY}:${rootDir}` : DOCUMENT_TREE_SORT_MODE_STORAGE_KEY;
 }
 
+export function documentTreeSortDirectionStorageKey(rootDir: string | null) {
+  return rootDir ? `${DOCUMENT_TREE_SORT_DIRECTION_STORAGE_KEY}:${rootDir}` : DOCUMENT_TREE_SORT_DIRECTION_STORAGE_KEY;
+}
+
 export function readStoredSortMode(rootDir: string | null = null): DocumentTreeSortMode {
   if (typeof window === "undefined") {
     return "name";
@@ -443,14 +478,53 @@ export function writeStoredSortMode(rootDir: string | null, sortMode: DocumentTr
   }
 }
 
+export function readStoredSortDirection(
+  rootDir: string | null = null,
+  sortMode: DocumentTreeSortMode = "name",
+): DocumentTreeSortDirection {
+  if (typeof window === "undefined") {
+    return defaultSortDirection(sortMode);
+  }
+
+  try {
+    return parseSortDirection(window.localStorage.getItem(documentTreeSortDirectionStorageKey(rootDir)), sortMode);
+  } catch {
+    return defaultSortDirection(sortMode);
+  }
+}
+
+export function writeStoredSortDirection(rootDir: string | null, sortDirection: DocumentTreeSortDirection) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(documentTreeSortDirectionStorageKey(rootDir), sortDirection);
+  } catch {
+    // Keep sorting usable even if local storage is unavailable.
+  }
+}
+
 export function parseSortMode(value: unknown): DocumentTreeSortMode {
   return value === "path" || value === "modified" || value === "size" ? value : "name";
+}
+
+export function parseSortDirection(
+  value: unknown,
+  sortMode: DocumentTreeSortMode = "name",
+): DocumentTreeSortDirection {
+  return value === "asc" || value === "desc" ? value : defaultSortDirection(sortMode);
+}
+
+export function defaultSortDirection(sortMode: DocumentTreeSortMode): DocumentTreeSortDirection {
+  return sortMode === "modified" || sortMode === "size" ? "desc" : "asc";
 }
 
 export function buildTree(
   files: string[],
   sortMode: DocumentTreeSortMode = "name",
   fileMetadata: Record<string, MarkdownFileMetadata> = {},
+  sortDirection: DocumentTreeSortDirection = defaultSortDirection(sortMode),
 ) {
   const root: TreeNodeData[] = [];
 
@@ -458,7 +532,7 @@ export function buildTree(
     insertNode(root, file.split("/"), "", file);
   }
 
-  return sortTree(root, sortMode, fileMetadata);
+  return sortTree(root, sortMode, fileMetadata, sortDirection);
 }
 
 function insertNode(nodes: TreeNodeData[], segments: string[], parentPath: string, originalPath: string) {
@@ -495,34 +569,37 @@ function sortTree(
   nodes: TreeNodeData[],
   sortMode: DocumentTreeSortMode,
   fileMetadata: Record<string, MarkdownFileMetadata>,
+  sortDirection: DocumentTreeSortDirection,
 ): TreeNodeData[] {
   return nodes
     .map((node) => ({
       ...node,
-      children: sortTree(node.children, sortMode, fileMetadata),
+      children: sortTree(node.children, sortMode, fileMetadata, sortDirection),
     }))
     .sort((left, right) => {
       if (left.kind !== right.kind) {
         return left.kind === "directory" ? -1 : 1;
       }
 
+      const directionMultiplier = sortDirection === "asc" ? 1 : -1;
+
       if (sortMode === "modified") {
-        const modifiedComparison = modifiedAt(right, fileMetadata) - modifiedAt(left, fileMetadata);
+        const modifiedComparison = modifiedAt(left, fileMetadata) - modifiedAt(right, fileMetadata);
         if (modifiedComparison !== 0) {
-          return modifiedComparison;
+          return modifiedComparison * directionMultiplier;
         }
       }
 
       if (sortMode === "size") {
-        const sizeComparison = sizeBytes(right, fileMetadata) - sizeBytes(left, fileMetadata);
+        const sizeComparison = sizeBytes(left, fileMetadata) - sizeBytes(right, fileMetadata);
         if (sizeComparison !== 0) {
-          return sizeComparison;
+          return sizeComparison * directionMultiplier;
         }
       }
 
       const leftValue = sortMode === "path" ? left.path : left.name;
       const rightValue = sortMode === "path" ? right.path : right.name;
-      return leftValue.localeCompare(rightValue);
+      return leftValue.localeCompare(rightValue) * directionMultiplier;
     });
 }
 


### PR DESCRIPTION
## Summary
- add an ascending/descending direction control next to the document tree sort mode
- default name/path to ascending and modified/size to descending
- persist the selected direction per root alongside the sort mode
- apply direction to same-kind tree ordering while preserving directory-first grouping
- add focused tests for direction defaults, persistence, and reversed sorting

## Validation
- pnpm test
- pnpm typecheck
- pnpm build
- cargo test --manifest-path src-tauri/Cargo.toml

Stacked after #126.
Closes #85