### PR TITLE
feat: remember sort direction per mode

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1089,8 +1089,11 @@ mod tests {
     use notify::event::{CreateKind, DataChange, RemoveKind, RenameMode};
     use std::{
         fs,
+        sync::atomic::{AtomicU64, Ordering},
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     struct TestDir {
         path: PathBuf,
@@ -1102,8 +1105,13 @@ mod tests {
                 .duration_since(UNIX_EPOCH)
                 .expect("system clock should be after Unix epoch")
                 .as_nanos();
-            let path =
-                env::temp_dir().join(format!("markmini-test-{}-{}", std::process::id(), unique));
+            let counter = TEST_DIR_COUNTER.fetch_add(1, Ordering::SeqCst);
+            let path = env::temp_dir().join(format!(
+                "markmini-test-{}-{}-{}",
+                std::process::id(),
+                unique,
+                counter
+            ));
             fs::create_dir_all(&path).expect("test directory should be created");
             Self { path }
         }

--- a/src/components/file-tree.test.ts
+++ b/src/components/file-tree.test.ts
@@ -5,6 +5,7 @@ import {
   DOCUMENT_TREE_SORT_MODE_STORAGE_KEY,
   buildTree,
   defaultSortDirection,
+  documentTreeSortDirectionForModeStorageKey,
   documentTreeSortDirectionStorageKey,
   documentTreeSortModeStorageKey,
   filterFiles,
@@ -13,10 +14,12 @@ import {
   formatModifiedAt,
   parseSortDirection,
   parseSortMode,
+  readStoredSortDirectionForMode,
   readStoredSortDirection,
   readStoredSortMode,
   treeNodeIndent,
   writeStoredSortDirection,
+  writeStoredSortDirectionForMode,
   writeStoredSortMode,
 } from "./file-tree";
 
@@ -171,6 +174,27 @@ describe("document tree sorting", () => {
     expect(localStorage.getItem(`${DOCUMENT_TREE_SORT_DIRECTION_STORAGE_KEY}:/vault-b`)).toBe("asc");
     expect(readStoredSortDirection("/vault-a", "name")).toBe("desc");
     expect(readStoredSortDirection("/vault-b", "modified")).toBe("asc");
+  });
+
+  it("stores and restores sort direction per root and sort mode", () => {
+    const localStorage = installLocalStorageMock();
+
+    writeStoredSortDirection("/vault", "desc");
+    writeStoredSortDirectionForMode("/vault", "name", "asc");
+    writeStoredSortDirectionForMode("/vault", "modified", "desc");
+
+    expect(localStorage.getItem(documentTreeSortDirectionForModeStorageKey("/vault", "name"))).toBe("asc");
+    expect(readStoredSortDirectionForMode("/vault", "name")).toBe("asc");
+    expect(readStoredSortDirectionForMode("/vault", "modified")).toBe("desc");
+  });
+
+  it("falls back to the legacy root-level direction before using mode defaults", () => {
+    installLocalStorageMock();
+
+    writeStoredSortDirection("/vault", "asc");
+
+    expect(readStoredSortDirectionForMode("/vault", "size")).toBe("asc");
+    expect(readStoredSortDirectionForMode("/other", "size")).toBe("desc");
   });
 
   it("sorts files and directories by newest modified time when metadata is available", () => {

--- a/src/components/file-tree.tsx
+++ b/src/components/file-tree.tsx
@@ -27,9 +27,10 @@ interface FileTreeProps {
 export function FileTree({ rootDir, files, fileMetadata, scanState, skippedCount, selectedFile, onSelect }: FileTreeProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [sortMode, setSortMode] = useState<DocumentTreeSortMode>(() => readStoredSortMode(rootDir));
-  const [sortDirection, setSortDirection] = useState<DocumentTreeSortDirection>(() =>
-    readStoredSortDirection(rootDir, readStoredSortMode(rootDir)),
-  );
+  const [sortDirection, setSortDirection] = useState<DocumentTreeSortDirection>(() => {
+    const initialSortMode = readStoredSortMode(rootDir);
+    return readStoredSortDirectionForMode(rootDir, initialSortMode);
+  });
   const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredFiles = useMemo(() => filterFiles(files, normalizedSearchQuery), [files, normalizedSearchQuery]);
   const tree = useMemo(
@@ -46,7 +47,7 @@ export function FileTree({ rootDir, files, fileMetadata, scanState, skippedCount
   useEffect(() => {
     const storedSortMode = readStoredSortMode(rootDir);
     setSortMode(storedSortMode);
-    setSortDirection(readStoredSortDirection(rootDir, storedSortMode));
+    setSortDirection(readStoredSortDirectionForMode(rootDir, storedSortMode));
   }, [rootDir]);
 
   useEffect(() => {
@@ -55,7 +56,8 @@ export function FileTree({ rootDir, files, fileMetadata, scanState, skippedCount
 
   useEffect(() => {
     writeStoredSortDirection(rootDir, sortDirection);
-  }, [rootDir, sortDirection]);
+    writeStoredSortDirectionForMode(rootDir, sortMode, sortDirection);
+  }, [rootDir, sortDirection, sortMode]);
 
   useEffect(() => {
     setExpandedPaths((current) => {
@@ -114,7 +116,7 @@ export function FileTree({ rootDir, files, fileMetadata, scanState, skippedCount
   const handleSortModeChange = (value: string) => {
     const nextSortMode = parseSortMode(value);
     setSortMode(nextSortMode);
-    setSortDirection(defaultSortDirection(nextSortMode));
+    setSortDirection(readStoredSortDirectionForMode(rootDir, nextSortMode));
   };
 
   const handleTreeKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
@@ -454,6 +456,10 @@ export function documentTreeSortDirectionStorageKey(rootDir: string | null) {
   return rootDir ? `${DOCUMENT_TREE_SORT_DIRECTION_STORAGE_KEY}:${rootDir}` : DOCUMENT_TREE_SORT_DIRECTION_STORAGE_KEY;
 }
 
+export function documentTreeSortDirectionForModeStorageKey(rootDir: string | null, sortMode: DocumentTreeSortMode) {
+  return `${documentTreeSortDirectionStorageKey(rootDir)}:${sortMode}`;
+}
+
 export function readStoredSortMode(rootDir: string | null = null): DocumentTreeSortMode {
   if (typeof window === "undefined") {
     return "name";
@@ -500,6 +506,42 @@ export function writeStoredSortDirection(rootDir: string | null, sortDirection: 
 
   try {
     window.localStorage.setItem(documentTreeSortDirectionStorageKey(rootDir), sortDirection);
+  } catch {
+    // Keep sorting usable even if local storage is unavailable.
+  }
+}
+
+export function readStoredSortDirectionForMode(
+  rootDir: string | null,
+  sortMode: DocumentTreeSortMode,
+): DocumentTreeSortDirection {
+  if (typeof window === "undefined") {
+    return defaultSortDirection(sortMode);
+  }
+
+  try {
+    const modeDirection = window.localStorage.getItem(documentTreeSortDirectionForModeStorageKey(rootDir, sortMode));
+    if (modeDirection) {
+      return parseSortDirection(modeDirection, sortMode);
+    }
+
+    return parseSortDirection(window.localStorage.getItem(documentTreeSortDirectionStorageKey(rootDir)), sortMode);
+  } catch {
+    return defaultSortDirection(sortMode);
+  }
+}
+
+export function writeStoredSortDirectionForMode(
+  rootDir: string | null,
+  sortMode: DocumentTreeSortMode,
+  sortDirection: DocumentTreeSortDirection,
+) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(documentTreeSortDirectionForModeStorageKey(rootDir, sortMode), sortDirection);
   } catch {
     // Keep sorting usable even if local storage is unavailable.
   }


### PR DESCRIPTION
## Summary
- persist sort direction by root and sort mode
- restore mode-specific direction when switching sort modes
- preserve compatibility with the existing root-level sort direction key as a fallback
- keep sensible first-use defaults for name/path vs modified/size modes
- add focused tests for mode-specific direction storage and legacy fallback
- make backend temp test directories collision-resistant while validating the stack

## Validation
- pnpm test
- pnpm typecheck
- pnpm build
- cargo test --manifest-path src-tauri/Cargo.toml

Stacked after #127.
Closes #87