### PR TITLE
docs: align README validation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,17 @@ pnpm dev
 
 ## 검증
 
+PR을 열기 전에는 아래 순서로 로컬 검증을 실행합니다.
+
 ```bash
+pnpm test
 pnpm typecheck
-cargo check --manifest-path src-tauri/Cargo.toml
 pnpm build
+cargo test --manifest-path src-tauri/Cargo.toml
+cargo check --manifest-path src-tauri/Cargo.toml
 ```
 
-빌드·설치·macOS Gatekeeper 대응 등 자세한 내용은 [빌드 및 설치 가이드](./docs/build-and-install.md)를 참고하세요.
+빌드·설치·macOS Gatekeeper 대응과 aggregate validation script는 [빌드 및 설치 가이드](./docs/build-and-install.md)를 참고하세요.
 
 ## 기술 스택
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -999,8 +999,11 @@ mod tests {
     use notify::event::{CreateKind, DataChange, RemoveKind, RenameMode};
     use std::{
         fs,
+        sync::atomic::{AtomicU64, Ordering},
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     struct TestDir {
         path: PathBuf,
@@ -1012,8 +1015,13 @@ mod tests {
                 .duration_since(UNIX_EPOCH)
                 .expect("system clock should be after Unix epoch")
                 .as_nanos();
-            let path =
-                env::temp_dir().join(format!("markmini-test-{}-{}", std::process::id(), unique));
+            let sequence = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = env::temp_dir().join(format!(
+                "markmini-test-{}-{}-{}",
+                std::process::id(),
+                unique,
+                sequence
+            ));
             fs::create_dir_all(&path).expect("test directory should be created");
             Self { path }
         }


### PR DESCRIPTION
## Summary
- update README validation commands to include frontend tests and Rust tests
- mention aggregate validation scripts in the detailed build/install guide
- harden Rust test temp directory names after validation exposed a parallel-test collision

## Validation
- pnpm test
- pnpm typecheck
- pnpm build
- cargo test --manifest-path src-tauri/Cargo.toml
- cargo check --manifest-path src-tauri/Cargo.toml

Closes #135
Closes #136