### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+- 
+
+## Linked issues
+
+Closes #
+
+## Branch policy
+
+- [ ] This PR targets the correct base branch.
+- [ ] If this targets `main`, it keeps `main` viewer-only and does not introduce edit/save/write flows.
+- [ ] If this is editing work, it targets `feat/markdown-editing` or a branch stacked on top of it.
+- [ ] I checked the relevant policy docs:
+  - [Branch Policy](../docs/branch-policy.md)
+  - [Document Tree PR Status](../docs/document-tree-pr-status.md)
+
+## Validation
+
+Run the relevant checks and mark what passed:
+
+- [ ] `pnpm test`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm build`
+- [ ] `cargo test --manifest-path src-tauri/Cargo.toml`
+- [ ] `cargo check --manifest-path src-tauri/Cargo.toml`
+- [ ] Not applicable; this is a docs-only or metadata-only change.
+
+Notes:
+
+- 


### PR DESCRIPTION
## Summary
- add a GitHub pull request template
- prompt contributors to confirm viewer-only vs editing branch policy
- add validation checklist entries for frontend and Tauri checks

## Validation
- pnpm typecheck

Closes #140