### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.rs]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.toml]
+indent_size = 2


### PR DESCRIPTION
## Summary
- add root `.editorconfig` for baseline editor formatting
- set UTF-8, LF, final newline, trimming, and space indentation defaults
- keep Rust files at four-space indentation and preserve Markdown trailing spaces

## Validation
- pnpm typecheck

Closes #146