### PR TITLE
ci: harden validation workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: validation-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -14,6 +17,7 @@ jobs:
   validate:
     name: Viewer validation
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- set validation workflow permissions to contents: read
- add a 30-minute timeout to the validation job
- keep existing validation steps unchanged

## Validation
- pnpm typecheck

Closes #154