### PR TITLE
docs: align README validation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,17 @@ pnpm dev
 
 ## 검증
 
+로컬에서 PR을 올리기 전에 아래 순서로 viewer/frontend와 Tauri backend를 함께 확인합니다.
+
 ```bash
+pnpm test
 pnpm typecheck
+cargo test --manifest-path src-tauri/Cargo.toml
 cargo check --manifest-path src-tauri/Cargo.toml
 pnpm build
 ```
+
+변경 범위가 frontend-only인 경우에도 `pnpm test`, `pnpm typecheck`, `pnpm build`는 기본으로 실행합니다. Tauri command, 파일 탐색, watcher, metadata payload를 건드렸다면 Cargo test/check도 함께 실행합니다.
 
 빌드·설치·macOS Gatekeeper 대응 등 자세한 내용은 [빌드 및 설치 가이드](./docs/build-and-install.md)를 참고하세요.
 


### PR DESCRIPTION
## Summary
- refresh README validation commands on current main
- include frontend tests, typecheck, Tauri backend test/check, and frontend build
- document when Cargo validation is expected for Tauri/file metadata changes

## Validation
- pnpm test
- pnpm typecheck
- cargo test --manifest-path src-tauri/Cargo.toml
- cargo check --manifest-path src-tauri/Cargo.toml
- pnpm build

Closes #135